### PR TITLE
Fix: UnboundLocalError: local variable 'version_type' referenced before assignment

### DIFF
--- a/vcs2l/clients/git.py
+++ b/vcs2l/clients/git.py
@@ -725,6 +725,8 @@ class GitClient(VcsClientBase):
             else:
                 for _hash in hashes:
                     if _hash.startswith(command.version):
+                        version_type = 'hash'
+                        version_name = command.version
                         break
                 else:
                     cmd = result_ls_remote['cmd']


### PR DESCRIPTION
rebased version of https://github.com/dirk-thomas/vcstool/pull/239

ping @furushchev FYI

We use this this fix for our internal codebase. If this is merged we could switch back to an official release.

should fix https://github.com/dirk-thomas/vcstool/issues/271