### PR TITLE
Migrate tests to use ros-infrastructure link

### DIFF
--- a/test/branch.txt
+++ b/test/branch.txt
@@ -3,7 +3,7 @@
 (HEAD detached at 377d5b3)
 === ./immutable/tag (git) ===
 (HEAD detached at 0.1.27)
-=== ./vcstool (git) ===
+=== ./vcs2l (git) ===
 master
 === ./without_version (git) ===
 master

--- a/test/export_exact.txt
+++ b/test/export_exact.txt
@@ -1,9 +1,9 @@
 repositories:
   hash:
     type: git
-    url: https://github.com/dirk-thomas/vcstool.git
+    url: https://github.com/ros-infrastructure/vcs2l.git
     version: 377d5b3d03c212f015cc832fdb368f4534d0d583
   tag:
     type: git
-    url: https://github.com/dirk-thomas/vcstool.git
+    url: https://github.com/ros-infrastructure/vcs2l.git
     version: bf9ca56de693a02b93ed423bcef589259d75eb0f

--- a/test/export_exact_with_tags.txt
+++ b/test/export_exact_with_tags.txt
@@ -1,9 +1,9 @@
 repositories:
   hash:
     type: git
-    url: https://github.com/dirk-thomas/vcstool.git
+    url: https://github.com/ros-infrastructure/vcs2l.git
     version: 377d5b3d03c212f015cc832fdb368f4534d0d583
   tag:
     type: git
-    url: https://github.com/dirk-thomas/vcstool.git
+    url: https://github.com/ros-infrastructure/vcs2l.git
     version: 0.1.27

--- a/test/import.txt
+++ b/test/import.txt
@@ -20,9 +20,9 @@ Turn off this advice by setting config variable advice.detachedHead to false
 
 HEAD is now at 377d5b3... update changelog
 === ./immutable/hash_tar (tar) ===
-Downloaded tarball from 'https://github.com/dirk-thomas/vcstool/archive/377d5b3d03c212f015cc832fdb368f4534d0d583.tar.gz' and unpacked it
+Downloaded tarball from 'https://github.com/ros-infrastructure/vcs2l/archive/377d5b3d03c212f015cc832fdb368f4534d0d583.tar.gz' and unpacked it
 === ./immutable/hash_zip (zip) ===
-Downloaded zipfile from 'https://github.com/dirk-thomas/vcstool/archive/377d5b3d03c212f015cc832fdb368f4534d0d583.zip' and unpacked it
+Downloaded zipfile from 'https://github.com/ros-infrastructure/vcs2l/archive/377d5b3d03c212f015cc832fdb368f4534d0d583.zip' and unpacked it
 === ./immutable/tag (git) ===
 Cloning into '.'...
 Note: switching to 'tags/0.1.27'.
@@ -43,7 +43,7 @@ Or undo this operation with:
 Turn off this advice by setting config variable advice.detachedHead to false
 
 HEAD is now at bf9ca56... 0.1.27
-=== ./vcstool (git) ===
+=== ./vcs2l (git) ===
 Cloning into '.'...
 === ./without_version (git) ===
 Cloning into '.'...

--- a/test/import_shallow.txt
+++ b/test/import_shallow.txt
@@ -2,7 +2,7 @@
 === ./immutable/hash (git) ===
 Initialized empty Git repository in ./immutable/hash/.git/
 
-From https://github.com/dirk-thomas/vcstool
+From https://github.com/ros-infrastructure/vcs2l
  * branch            377d5b3d03c212f015cc832fdb368f4534d0d583 -> FETCH_HEAD
 Note: switching to '377d5b3d03c212f015cc832fdb368f4534d0d583'.
 
@@ -23,13 +23,13 @@ Turn off this advice by setting config variable advice.detachedHead to false
 
 HEAD is now at 377d5b3... update changelog
 === ./immutable/hash_tar (tar) ===
-Downloaded tarball from 'https://github.com/dirk-thomas/vcstool/archive/377d5b3d03c212f015cc832fdb368f4534d0d583.tar.gz' and unpacked it
+Downloaded tarball from 'https://github.com/ros-infrastructure/vcs2l/archive/377d5b3d03c212f015cc832fdb368f4534d0d583.tar.gz' and unpacked it
 === ./immutable/hash_zip (zip) ===
-Downloaded zipfile from 'https://github.com/dirk-thomas/vcstool/archive/377d5b3d03c212f015cc832fdb368f4534d0d583.zip' and unpacked it
+Downloaded zipfile from 'https://github.com/ros-infrastructure/vcs2l/archive/377d5b3d03c212f015cc832fdb368f4534d0d583.zip' and unpacked it
 === ./immutable/tag (git) ===
 Initialized empty Git repository in ./immutable/tag/.git/
 
-From https://github.com/dirk-thomas/vcstool
+From https://github.com/ros-infrastructure/vcs2l
  * [new tag]         0.1.27     -> 0.1.27
 Note: switching to 'tags/0.1.27'.
 
@@ -49,7 +49,7 @@ Or undo this operation with:
 Turn off this advice by setting config variable advice.detachedHead to false
 
 HEAD is now at bf9ca56... 0.1.27
-=== ./vcstool (git) ===
+=== ./vcs2l (git) ===
 Cloning into '.'...
 === ./without_version (git) ===
 Cloning into '.'...

--- a/test/list.repos
+++ b/test/list.repos
@@ -1,24 +1,24 @@
 repositories:
   immutable/hash:
     type: git
-    url: https://github.com/dirk-thomas/vcstool.git
+    url: https://github.com/ros-infrastructure/vcs2l.git
     version: 377d5b3d03c212f015cc832fdb368f4534d0d583
   immutable/hash_tar:
     type: tar
-    url: https://github.com/dirk-thomas/vcstool/archive/377d5b3d03c212f015cc832fdb368f4534d0d583.tar.gz
-    version: vcstool-377d5b3d03c212f015cc832fdb368f4534d0d583
+    url: https://github.com/ros-infrastructure/vcs2l/archive/377d5b3d03c212f015cc832fdb368f4534d0d583.tar.gz
+    version: vcs2l-377d5b3d03c212f015cc832fdb368f4534d0d583
   immutable/hash_zip:
     type: zip
-    url: https://github.com/dirk-thomas/vcstool/archive/377d5b3d03c212f015cc832fdb368f4534d0d583.zip
-    version: vcstool-377d5b3d03c212f015cc832fdb368f4534d0d583
+    url: https://github.com/ros-infrastructure/vcs2l/archive/377d5b3d03c212f015cc832fdb368f4534d0d583.zip
+    version: vcs2l-377d5b3d03c212f015cc832fdb368f4534d0d583
   immutable/tag:
     type: git
-    url: https://github.com/dirk-thomas/vcstool.git
+    url: https://github.com/ros-infrastructure/vcs2l.git
     version: tags/0.1.27
-  vcstool:
+  vcs2l:
     type: git
-    url: https://github.com/dirk-thomas/vcstool.git
+    url: https://github.com/ros-infrastructure/vcs2l.git
     version: heads/master
   without_version:
     type: git
-    url: https://github.com/dirk-thomas/vcstool.git
+    url: https://github.com/ros-infrastructure/vcs2l.git

--- a/test/list2.repos
+++ b/test/list2.repos
@@ -13,5 +13,5 @@ repositories:
     version: 5.8
   svn/rev:
     type: svn
-    url: https://github.com/dirk-thomas/vcstool
+    url: https://github.com/ros-infrastructure/vcs2l
     version: 3

--- a/test/pull.txt
+++ b/test/pull.txt
@@ -11,7 +11,7 @@ Please specify which branch you want to merge with.
 See git-pull(1) for details.
 
     git pull <remote> <branch>
-=== ./vcstool (git) ===
+=== ./vcs2l (git) ===
 Already up to date.
 === ./without_version (git) ===
 Already up to date.

--- a/test/reimport.txt
+++ b/test/reimport.txt
@@ -3,13 +3,13 @@
 
 HEAD is now at 377d5b3... update changelog
 === ./immutable/hash_tar (tar) ===
-Downloaded tarball from 'https://github.com/dirk-thomas/vcstool/archive/377d5b3d03c212f015cc832fdb368f4534d0d583.tar.gz' and unpacked it
+Downloaded tarball from 'https://github.com/ros-infrastructure/vcs2l/archive/377d5b3d03c212f015cc832fdb368f4534d0d583.tar.gz' and unpacked it
 === ./immutable/hash_zip (zip) ===
-Downloaded zipfile from 'https://github.com/dirk-thomas/vcstool/archive/377d5b3d03c212f015cc832fdb368f4534d0d583.zip' and unpacked it
+Downloaded zipfile from 'https://github.com/ros-infrastructure/vcs2l/archive/377d5b3d03c212f015cc832fdb368f4534d0d583.zip' and unpacked it
 === ./immutable/tag (git) ===
 
 HEAD is now at bf9ca56... 0.1.27
-=== ./vcstool (git) ===
+=== ./vcs2l (git) ===
 
 Already on 'master'
 Your branch is up to date with 'origin/master'.

--- a/test/reimport_force.txt
+++ b/test/reimport_force.txt
@@ -3,13 +3,13 @@
 
 HEAD is now at 377d5b3... update changelog
 === ./immutable/hash_tar (tar) ===
-Downloaded tarball from 'https://github.com/dirk-thomas/vcstool/archive/377d5b3d03c212f015cc832fdb368f4534d0d583.tar.gz' and unpacked it
+Downloaded tarball from 'https://github.com/ros-infrastructure/vcs2l/archive/377d5b3d03c212f015cc832fdb368f4534d0d583.tar.gz' and unpacked it
 === ./immutable/hash_zip (zip) ===
-Downloaded zipfile from 'https://github.com/dirk-thomas/vcstool/archive/377d5b3d03c212f015cc832fdb368f4534d0d583.zip' and unpacked it
+Downloaded zipfile from 'https://github.com/ros-infrastructure/vcs2l/archive/377d5b3d03c212f015cc832fdb368f4534d0d583.zip' and unpacked it
 === ./immutable/tag (git) ===
 
 HEAD is now at bf9ca56... 0.1.27
-=== ./vcstool (git) ===
+=== ./vcs2l (git) ===
 
 Already on 'master'
 Your branch is up to date with 'origin/master'.

--- a/test/reimport_skip.txt
+++ b/test/reimport_skip.txt
@@ -1,9 +1,9 @@
 ......
 === ./immutable/hash (git) ===
 === ./immutable/hash_tar (tar) ===
-Downloaded tarball from 'https://github.com/dirk-thomas/vcstool/archive/377d5b3d03c212f015cc832fdb368f4534d0d583.tar.gz' and unpacked it
+Downloaded tarball from 'https://github.com/ros-infrastructure/vcs2l/archive/377d5b3d03c212f015cc832fdb368f4534d0d583.tar.gz' and unpacked it
 === ./immutable/hash_zip (zip) ===
-Downloaded zipfile from 'https://github.com/dirk-thomas/vcstool/archive/377d5b3d03c212f015cc832fdb368f4534d0d583.zip' and unpacked it
+Downloaded zipfile from 'https://github.com/ros-infrastructure/vcs2l/archive/377d5b3d03c212f015cc832fdb368f4534d0d583.zip' and unpacked it
 === ./immutable/tag (git) ===
-=== ./vcstool (git) ===
+=== ./vcs2l (git) ===
 === ./without_version (git) ===

--- a/test/remotes_repos.txt
+++ b/test/remotes_repos.txt
@@ -1,17 +1,17 @@
 ./immutable/hash (git)
 ./immutable/tag (git)
-./vcstool (git)
+./vcs2l (git)
 ./without_version (git)
 ....
 === ./immutable/hash (git) ===
-origin	https://github.com/dirk-thomas/vcstool.git (fetch)
-origin	https://github.com/dirk-thomas/vcstool.git (push)
+origin	https://github.com/ros-infrastructure/vcs2l.git (fetch)
+origin	https://github.com/ros-infrastructure/vcs2l.git (push)
 === ./immutable/tag (git) ===
-origin	https://github.com/dirk-thomas/vcstool.git (fetch)
-origin	https://github.com/dirk-thomas/vcstool.git (push)
-=== ./vcstool (git) ===
-origin	https://github.com/dirk-thomas/vcstool.git (fetch)
-origin	https://github.com/dirk-thomas/vcstool.git (push)
+origin	https://github.com/ros-infrastructure/vcs2l.git (fetch)
+origin	https://github.com/ros-infrastructure/vcs2l.git (push)
+=== ./vcs2l (git) ===
+origin	https://github.com/ros-infrastructure/vcs2l.git (fetch)
+origin	https://github.com/ros-infrastructure/vcs2l.git (push)
 === ./without_version (git) ===
-origin	https://github.com/dirk-thomas/vcstool.git (fetch)
-origin	https://github.com/dirk-thomas/vcstool.git (push)
+origin	https://github.com/ros-infrastructure/vcs2l.git (fetch)
+origin	https://github.com/ros-infrastructure/vcs2l.git (push)

--- a/test/status.txt
+++ b/test/status.txt
@@ -5,7 +5,7 @@ nothing to commit, working tree clean
 === ./immutable/tag (git) ===
 HEAD detached at 0.1.27
 nothing to commit, working tree clean
-=== ./vcstool (git) ===
+=== ./vcs2l (git) ===
 On branch master
 Your branch is up to date with 'origin/master'.
 

--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -200,7 +200,7 @@ invocation.
         assert output == expected
 
     def test_reimport(self):
-        cwd_vcs2l = os.path.join(TEST_WORKSPACE, 'vcstool')
+        cwd_vcs2l = os.path.join(TEST_WORKSPACE, 'vcs2l')
         subprocess.check_output(
             ['git', 'remote', 'add', 'foo', 'http://foo.com/bar.git'],
             stderr=subprocess.STDOUT, cwd=cwd_vcs2l)
@@ -253,12 +253,12 @@ invocation.
                 stderr=subprocess.STDOUT, cwd=cwd_tag)
             subprocess.check_output(
                 ['git', 'remote', 'add', 'origin',
-                 'https://github.com/dirk-thomas/vcstool.git'],
+                 'https://github.com/ros-infrastructure/vcs2l.git'],
                 stderr=subprocess.STDOUT, cwd=cwd_tag)
 
     def test_import_force_non_empty(self):
         workdir = os.path.join(TEST_WORKSPACE, 'force-non-empty')
-        os.makedirs(os.path.join(workdir, 'vcstool', 'not-a-git-repo'))
+        os.makedirs(os.path.join(workdir, 'vcs2l', 'not-a-git-repo'))
         try:
             output = run_command(
                 'import', ['--force', '--input', REPOS_FILE, '.'],
@@ -291,7 +291,7 @@ invocation.
             # check that repository history has only one commit
             output = subprocess.check_output(
                 ['git', 'log', '--format=oneline'],
-                stderr=subprocess.STDOUT, cwd=os.path.join(workdir, 'vcstool'))
+                stderr=subprocess.STDOUT, cwd=os.path.join(workdir, 'vcs2l'))
             assert len(output.splitlines()) == 1
         finally:
             rmtree(workdir)
@@ -415,7 +415,7 @@ def adapt_command_output(output, cwd=None):
         # this is less likely to cause wrong test results
         paths_to_replace = [
             (b'.\\immutable', b'./immutable'),
-            (b'.\\vcstool', b'./vcstool'),
+            (b'.\\vcs2l', b'./vcs2l'),
             (b'.\\without_version', b'./without_version'),
             (b'\\hash', b'/hash'),
             (b'\\tag', b'/tag'),

--- a/test/validate.txt
+++ b/test/validate.txt
@@ -1,13 +1,13 @@
 ......
 === immutable/hash (git) ===
-Found git repository 'https://github.com/dirk-thomas/vcstool.git' but unable to verify non-branch / non-tag ref '377d5b3d03c212f015cc832fdb368f4534d0d583' without cloning the repo
+Found git repository 'https://github.com/ros-infrastructure/vcs2l.git' but unable to verify non-branch / non-tag ref '377d5b3d03c212f015cc832fdb368f4534d0d583' without cloning the repo
 === immutable/hash_tar (tar) ===
-Tarball url 'https://github.com/dirk-thomas/vcstool/archive/377d5b3d03c212f015cc832fdb368f4534d0d583.tar.gz' exists
+Tarball url 'https://github.com/ros-infrastructure/vcs2l/archive/377d5b3d03c212f015cc832fdb368f4534d0d583.tar.gz' exists
 === immutable/hash_zip (zip) ===
-Zip url 'https://github.com/dirk-thomas/vcstool/archive/377d5b3d03c212f015cc832fdb368f4534d0d583.zip' exists
+Zip url 'https://github.com/ros-infrastructure/vcs2l/archive/377d5b3d03c212f015cc832fdb368f4534d0d583.zip' exists
 === immutable/tag (git) ===
-Found git repository 'https://github.com/dirk-thomas/vcstool.git' with tag '0.1.27'
-=== vcstool (git) ===
-Found git repository 'https://github.com/dirk-thomas/vcstool.git' with branch 'master'
+Found git repository 'https://github.com/ros-infrastructure/vcs2l.git' with tag '0.1.27'
+=== vcs2l (git) ===
+Found git repository 'https://github.com/ros-infrastructure/vcs2l.git' with branch 'master'
 === without_version (git) ===
-Found git repository 'https://github.com/dirk-thomas/vcstool.git' with default branch
+Found git repository 'https://github.com/ros-infrastructure/vcs2l.git' with default branch

--- a/test/validate2.txt
+++ b/test/validate2.txt
@@ -6,4 +6,4 @@ Found hg repository 'https://www.mercurial-scm.org/repo/hg-stable' with changese
 === hg/tag (hg) ===
 Found hg repository 'https://www.mercurial-scm.org/repo/hg-stable' with changeset '5.8'
 === svn/rev (svn) ===
-Found svn repository 'https://github.com/dirk-thomas/vcstool' with revision '3'
+Found svn repository 'https://github.com/ros-infrastructure/vcs2l' with revision '3'

--- a/test/validate_hide.txt
+++ b/test/validate_hide.txt
@@ -1,3 +1,3 @@
 ......
 === immutable/hash (git) ===
-Found git repository 'https://github.com/dirk-thomas/vcstool.git' but unable to verify non-branch / non-tag ref '377d5b3d03c212f015cc832fdb368f4534d0d583' without cloning the repo
+Found git repository 'https://github.com/ros-infrastructure/vcs2l.git' but unable to verify non-branch / non-tag ref '377d5b3d03c212f015cc832fdb368f4534d0d583' without cloning the repo


### PR DESCRIPTION
> [!NOTE]  
> #16  needs to be merged prior to the review of this PR.

## Basic Info

| Info | Result |
| ------ | ----------- |
| Primary OS tested on | Ubuntu |

## Description of contribution

- Renamed the temporary folder from `vcstool` to `vcs2l`.
- Migrated the testing link from `dirk-thomas/vcstool` to `ros-infrastructure/vcs2l`.
    
## Description of testing done

* Ran `pytest` locally to ensure all the unit and linting tests pass:

   ```bash
   pytest -s -v test
   ```
* Created a local fork to validate green CI.

Signed-off-by: Leander Stephen Desouza [leanderdsouza1234@gmail.com](mailto:leanderdsouza1234@gmail.com)