### PR TITLE
Add Python 3.5 support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,10 +15,11 @@ Note:
   * The file format of ``vcstool export`` uses the relative paths of the repositories as keys in YAML which avoids collisions by design.
   * ``vcstool`` has significantly fewer lines of code than ``vcstools`` including the command line tools built on top.
 
-Python 3.7+ support
+Python 3.5+ support
 ---------------------------
 
-The latest version supports Python 3.7 and newer.
+The latest version supports Python 3.5 and newer.
+However, the CI is only run on Python 3.7 and newer, as there are no suitable GitHub Actions `runners <https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json/>`_ available for Python 3.5 and 3.6.
 
 
 How does it work?

--- a/vcs2l/commands/help.py
+++ b/vcs2l/commands/help.py
@@ -11,6 +11,8 @@ if sys.version_info >= (3, 8):
     from importlib.metadata import entry_points
 elif sys.version_info >= (3, 7):
     from importlib_metadata import entry_points
+elif sys.version_info >= (3, 5):
+    from pkg_resources import load_entry_point
 else:
     raise UnsupportedPythonVersionError()
 
@@ -94,19 +96,25 @@ def get_entrypoint(command):
                 file=sys.stderr)
         return None
 
-    eps = entry_points()
     ep_name = 'vcs-' + commands[0]
 
     if sys.version_info >= (3, 10):
+        eps = entry_points()
         entry_point = next(iter(
             eps.select(group='console_scripts', name=ep_name)))
         if entry_point:
             return entry_point.load()
 
     elif sys.version_info >= (3, 7):
+        eps = entry_points()
         for ep in eps.get('console_scripts', []):
             if ep.name == ep_name:
                 return ep.load()
+
+    elif sys.version_info >= (3, 5):
+        return load_entry_point(
+            'vcs2l', 'console_scripts', ep_name)
+
     else:
         raise UnsupportedPythonVersionError()
 

--- a/vcs2l/errors.py
+++ b/vcs2l/errors.py
@@ -13,7 +13,7 @@ class Vcs2lError(Exception):
 class UnsupportedPythonVersionError(Vcs2lError):
     """Raised when the Python version is too old for vcs2l."""
 
-    def __init__(self, min_version: str = "3.7"):
+    def __init__(self, min_version: str = "3.5"):
         current_version = f"{sys.version_info.major}.{sys.version_info.minor}"
         message = (
             f"Unsupported Python version ({current_version}). "


### PR DESCRIPTION
## Basic Info

| Info | Result |
| ------ | ----------- |
| Primary OS tested on | Ubuntu |

## Description of contribution
- Added support for Python 3.5 by reverting the changes mentioned in #4
- Updated documentation regarding the discontinued support of GitHub runners for Python 3.5 and 3.6.
    
## Description of testing done

* Ran `pytest` locally to ensure all the unit and linting tests pass:

   ```bash
   pytest -s -v test
   ```
* Created a local fork to validate green CI.

Signed-off-by: Leander Stephen Desouza [leanderdsouza1234@gmail.com](mailto:leanderdsouza1234@gmail.com)