### PR TITLE
Configuration updates for stdeb release to bootstrap repository.

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,5 +1,5 @@
 [DEFAULT]
 No-Python2:
 Depends3: python3-setuptools, python3-yaml
-Conflicts3: python-vcstool
+Conflicts3: python-vcstool, python3-vcstool
 X-Python3-Version: >= 3.5

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -2,4 +2,5 @@
 No-Python2:
 Depends3: python3-setuptools, python3-yaml
 Conflicts3: python-vcstool, python3-vcstool
+Suite3: jammy noble bookworm trixie
 X-Python3-Version: >= 3.5


### PR DESCRIPTION
* Conflict our new vcs2l package with existing python3-vcstool installations

This is how we handle the python2 / python3 packages that both install
the same tool to /usr/bin so it seems reasonable to do for vcstool vs
vcs2l.

* Add release suites to stdeb.cfg.

When releasing with packagecloud the Suites field of the Debian changes
file was not used for controlling release suites and was removed. Now
that we are again releasing directly into the ROS bootstrap repository
our tools do use this field again.

Start by releasing into actively supported Ubuntu and Debian
distributions and expand support to older distributions only if needed