### PR TITLE
Rename master branch reference to main in tests.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,6 @@ jobs:
       run: |
         pip install --upgrade .[test]
         pip install --upgrade coverage
-        git config --global --add init.defaultBranch master
+        git config --global --add init.defaultBranch main
         git config --global --add advice.detachedHead true
         ${{ startsWith(matrix.os, 'windows') && 'set PYTHONPATH=%cd% &&' || 'PYTHONPATH=`pwd`' }} pytest -s -v test

--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,7 @@ This results in something similar to the following for a set of two repositories
     vcs2l:
       type: git
       url: git@github.com:ros-infrastructure/vcs2l.git
-      version: master
+      version: main
     old_tools/rosinstall:
       type: svn
       url: https://github.com/vcstools/rosinstall/trunk

--- a/test/branch.txt
+++ b/test/branch.txt
@@ -4,6 +4,6 @@
 === ./immutable/tag (git) ===
 (HEAD detached at 0.1.27)
 === ./vcs2l (git) ===
-master
+main
 === ./without_version (git) ===
-master
+main

--- a/test/list.repos
+++ b/test/list.repos
@@ -18,7 +18,7 @@ repositories:
   vcs2l:
     type: git
     url: https://github.com/ros-infrastructure/vcs2l.git
-    version: heads/master
+    version: heads/main
   without_version:
     type: git
     url: https://github.com/ros-infrastructure/vcs2l.git

--- a/test/reimport.txt
+++ b/test/reimport.txt
@@ -11,9 +11,9 @@ Downloaded zipfile from 'https://github.com/ros-infrastructure/vcs2l/archive/377
 HEAD is now at bf9ca56... 0.1.27
 === ./vcs2l (git) ===
 
-Already on 'master'
-Your branch is up to date with 'origin/master'.
+Already on 'main'
+Your branch is up to date with 'origin/main'.
 === ./without_version (git) ===
 
-Switched to branch 'master'
-Your branch is up to date with 'origin/master'.
+Switched to branch 'main'
+Your branch is up to date with 'origin/main'.

--- a/test/reimport_force.txt
+++ b/test/reimport_force.txt
@@ -11,7 +11,7 @@ Downloaded zipfile from 'https://github.com/ros-infrastructure/vcs2l/archive/377
 HEAD is now at bf9ca56... 0.1.27
 === ./vcs2l (git) ===
 
-Already on 'master'
-Your branch is up to date with 'origin/master'.
+Already on 'main'
+Your branch is up to date with 'origin/main'.
 === ./without_version (git) ===
 Cloning into '.'...

--- a/test/status.txt
+++ b/test/status.txt
@@ -6,12 +6,12 @@ nothing to commit, working tree clean
 HEAD detached at 0.1.27
 nothing to commit, working tree clean
 === ./vcs2l (git) ===
-On branch master
-Your branch is up to date with 'origin/master'.
+On branch main
+Your branch is up to date with 'origin/main'.
 
 nothing to commit, working tree clean
 === ./without_version (git) ===
-On branch master
-Your branch is up to date with 'origin/master'.
+On branch main
+Your branch is up to date with 'origin/main'.
 
 nothing to commit, working tree clean

--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -223,12 +223,12 @@ invocation.
         output = run_command(
             'import', ['--force', '--input', REPOS_FILE, '.'])
         expected = get_expected_output('reimport_force')
-        # on Windows, the "Already on 'master'" message is after the
+        # on Windows, the "Already on 'main'" message is after the
         # "Your branch is up to date with ..." message, so remove it
         # from both output and expected strings
         if sys.platform == 'win32':
-            output = output.replace(b"Already on 'master'\r\n", b'')
-            expected = expected.replace(b"Already on 'master'\r\n", b'')
+            output = output.replace(b"Already on 'main'\r\n", b'')
+            expected = expected.replace(b"Already on 'main'\r\n", b'')
         # newer git versions don't append three dots after the commit hash
         assert output == expected or output == expected.replace(b'... ', b' ')
 
@@ -378,14 +378,14 @@ def adapt_command_output(output, cwd=None):
     output = output.replace(
         b'(detached from ', b'(HEAD detached at ')
     output = output.replace(
-        b"ady on 'master'\n=",
-        b"ady on 'master'\nYour branch is up-to-date with 'origin/master'.\n=")
+        b"ady on 'main'\n=",
+        b"ady on 'main'\nYour branch is up-to-date with 'origin/main'.\n=")
     output = output.replace(
         b'# HEAD detached at ',
         b'HEAD detached at ')
     output = output.replace(
-        b'# On branch master',
-        b"On branch master\nYour branch is up-to-date with 'origin/master'.\n")
+        b'# On branch main',
+        b"On branch main\nYour branch is up-to-date with 'origin/main'.\n")
     # the following seems to have changed between git 2.17.1 and 2.25.1
     output = output.replace(
         b"Note: checking out '", b"Note: switching to '")

--- a/test/validate.txt
+++ b/test/validate.txt
@@ -8,6 +8,6 @@ Zip url 'https://github.com/ros-infrastructure/vcs2l/archive/377d5b3d03c212f015c
 === immutable/tag (git) ===
 Found git repository 'https://github.com/ros-infrastructure/vcs2l.git' with tag '0.1.27'
 === vcs2l (git) ===
-Found git repository 'https://github.com/ros-infrastructure/vcs2l.git' with branch 'master'
+Found git repository 'https://github.com/ros-infrastructure/vcs2l.git' with branch 'main'
 === without_version (git) ===
 Found git repository 'https://github.com/ros-infrastructure/vcs2l.git' with default branch


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A |
| Primary OS tested on | Ubuntu|
| Is this a breaking change? | No |
| Does this PR contain [AI generated](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md) software? | No|

---

## Description of contribution in a few bullet points
- Renamed master to main references to the branch in tests.

## Description of how this change was tested

* Ran `pytest` locally to ensure all the unit and linting tests pass:

   ```bash
   pytest -s -v test
   ```
* Created a local fork to validate green CI.

Signed-off-by: Leander Stephen Desouza [leanderdsouza1234@gmail.com](mailto:leanderdsouza1234@gmail.com)