### PR TITLE
Enable retry flag for vcs import.

### DIFF
--- a/vcs2l/clients/git.py
+++ b/vcs2l/clients/git.py
@@ -325,7 +325,7 @@ class GitClient(VcsClientBase):
             cmd_fetch = [GitClient._executable, 'fetch', remote]
             if command.shallow:
                 result_version_type, version_name = self._check_version_type(
-                    command.url, checkout_version
+                    command.url, checkout_version, command.retry
                 )
                 if result_version_type['returncode']:
                     return result_version_type
@@ -398,7 +398,7 @@ class GitClient(VcsClientBase):
             version_type = None
             if command.version:
                 result_version_type, version_name = self._check_version_type(
-                    command.url, command.version
+                    command.url, command.version, command.retry
                 )
                 if result_version_type['returncode']:
                     return result_version_type
@@ -523,7 +523,7 @@ class GitClient(VcsClientBase):
             'returncode': 0 if remote_urls else 1,
         }
 
-    def _check_version_type(self, url, version):
+    def _check_version_type(self, url, version, retry=0):
         # check if version starts with heads/ or tags/
         prefixes = {
             'heads/': 'branch',
@@ -540,7 +540,7 @@ class GitClient(VcsClientBase):
                 }, version[len(prefix) :]
 
         cmd = [GitClient._executable, 'ls-remote', url, version]
-        result = self._run_command(cmd)
+        result = self._run_command(cmd, retry=retry)
         if result['returncode']:
             result['output'] = (
                 'Could not determine ref type of version: ' + result['output']

--- a/vcs2l/clients/vcs_base.py
+++ b/vcs2l/clients/vcs_base.py
@@ -1,9 +1,12 @@
 import os
 import socket
 import subprocess
+import sys
 import time
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
+
+from vcs2l.executor import ansi
 
 
 class VcsClientBase(object):
@@ -35,6 +38,13 @@ class VcsClientBase(object):
 
     def _run_command(self, cmd, env=None, retry=0):
         for i in range(retry + 1):
+            if i > 0:
+                print(
+                    ansi('yellowf')
+                    + 'Retrying command (%d/%d): %s' % (i, retry, ' '.join(cmd))
+                    + ansi('reset'),
+                    file=sys.stderr,
+                )
             result = run_command(cmd, os.path.abspath(self.path), env=env)
             if not result['returncode']:
                 # return successful result


### PR DESCRIPTION
> [!NOTE]  
> #27 needs to be merged prior to the review of this PR.

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | [#198](https://github.com/dirk-thomas/vcstool/issues/198)  [#265](https://github.com/dirk-thomas/vcstool/pull/265)|
| Primary OS tested on | Ubuntu|
| Is this a breaking change? | No |
| Does this PR contain [AI generated](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md) software? | No |

---

## Description of contribution in a few bullet points
* This is a direct port of  [#265](https://github.com/dirk-thomas/vcstool/pull/265).

* There are two commands in `vcs` that have the ability to retry - `validate` and `import`.
   Both of these functions run `ls-remote`; however, only `validate` has the [`self.run_command()`](https://github.com/ros-infrastructure/vcs2l/blob/main/vcs2l/clients/git.py#L670) function enabled with the retry flag.

   This is missing from the `import` command as seen [here](https://github.com/ros-infrastructure/vcs2l/blob/main/vcs2l/clients/git.py#L517).

## Description of how this change was tested

* Run the export command at the root of the repository on the main branch:

   ```bash
   vcs export . > repos.yaml
   ```
   ```yaml
   repositories:
     vcs2l:
       type: git
       url: git@github.com:ros-infrastructure/vcs2l.git
       version: leander-dsouza/enable-import-retry
   ```
* Next, disable your local connection, and run the import command to view the retry logs:
   ```bash
   mkdir temp && cd temp
   vcs import --input ../repos.yaml .

   Retrying command (1/2): /usr/bin/git ls-remote git@github.com:ros-infrastructure/vcs2l.git leander-dsouza/enable-import-retry
   Retrying command (2/2): /usr/bin/git ls-remote git@github.com:ros-infrastructure/vcs2l.git leander-dsouza/enable-import-retry

   === ./vcs2l (git) ===
   Could not determine ref type of version: ssh: Could not resolve hostname github.com: Temporary failure in name    resolution
   fatal: Could not read from remote repository.

   Please make sure you have the correct access rights
   and the repository exists.
   ```