### PR TITLE
Added debug support for empty repository entries

### DIFF
--- a/test/bad.repos
+++ b/test/bad.repos
@@ -1,0 +1,6 @@
+repositories:
+  empty_entry:
+  missing_url:
+    type: git
+  missing_type:
+    url: https://github.com/ros-infrastructure/vcs2l.git

--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -14,6 +14,7 @@ file_uri_scheme = 'file://' if sys.platform != 'win32' else 'file:///'
 REPOS_FILE = os.path.join(os.path.dirname(__file__), 'list.repos')
 REPOS_FILE_URL = file_uri_scheme + REPOS_FILE
 REPOS2_FILE = os.path.join(os.path.dirname(__file__), 'list2.repos')
+BAD_REPOS_FILE = os.path.join(os.path.dirname(__file__), 'bad.repos')
 TEST_WORKSPACE = os.path.join(
     os.path.dirname(os.path.dirname(__file__)), 'test_workspace'
 )
@@ -335,6 +336,10 @@ invocation.
 
         output = run_command('validate', ['--hide-empty', '--input', REPOS_FILE])
         expected = get_expected_output('validate_hide')
+        self.assertEqual(output, expected)
+
+        output = run_command('validate', ['--input', BAD_REPOS_FILE])
+        expected = get_expected_output('validate_bad')
         self.assertEqual(output, expected)
 
     @unittest.skipIf(CI, 'Cannot run on CI')

--- a/test/validate_bad.txt
+++ b/test/validate_bad.txt
@@ -1,0 +1,3 @@
+Repository 'empty_entry' is empty, skipping
+Repository 'missing_url' does not provide the necessary information: 'url'
+Repository 'missing_type' does not provide the necessary information: 'type'

--- a/vcs2l/commands/import_.py
+++ b/vcs2l/commands/import_.py
@@ -116,6 +116,14 @@ def get_repos_in_vcs2l_format(repositories):
     for path in repositories:
         repo = {}
         attributes = repositories[path]
+        if not attributes:
+            print(
+                ansi('yellowf')
+                + "Repository '%s' is empty, skipping" % path
+                + ansi('reset'),
+                file=sys.stderr,
+            )
+            continue
         try:
             repo['type'] = attributes['type']
             repo['url'] = attributes['url']


### PR DESCRIPTION
> [!NOTE]  
> #27 needs to be merged prior to the review of this PR.

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |  [#256](https://github.com/dirk-thomas/vcstool/pull/256)|
| Primary OS tested on | Ubuntu|
| Is this a breaking change? | No |
| Does this PR contain [AI generated](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md) software? | No |

---

## Description of contribution in a few bullet points
* This is a direct port of  [#256](https://github.com/dirk-thomas/vcstool/pull/256).
* Fixed edge case for validation if the repository is missing both `url` and `type`.
* Added test cases to validate repositories missing `url`, `type`, and both.

## Description of how this change was tested

* Ran `pytest` locally to ensure all the unit and linting tests pass:

   ```bash
   pytest -s -v test
   ```
* Created a local fork to validate green CI.

Signed-off-by: Leander Stephen Desouza [leanderdsouza1234@gmail.com](mailto:leanderdsouza1234@gmail.com)