### PR TITLE
Add python 3.7 and 3.8 to CI workflow.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,11 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-22.04, ubuntu-24.04, windows-2022, windows-2025]
         python-version: ["3.10", "3.12"]
+        include:
+          - os: ubuntu-22.04
+            python-version: "3.7"
+          - os: ubuntu-22.04
+            python-version: "3.8"
 
     steps:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A |
| Primary OS tested on | N/A |
| Is this a breaking change? | No |
| Does this PR contain [AI generated](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md) software? | No |

---

## Description of contribution in a few bullet points
* Added Python 3.7 and Python 3.8 to the CI to support running on Debian Buster and Ubuntu Focal.

* However, the additional versions cannot target Ubuntu 20.04, as the GitHub runner is [deprecated](https://github.com/actions/runner-images/issues/11101).

* In addition, these versions cannot run on all the operating systems mentioned in the matrix CI, as these releases are out of the bounds of support as described [here](https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json).

## Description of how this change was tested
* N/A
