### PR TITLE
Added support for git submodules.

### DIFF
--- a/vcs2l/clients/git.py
+++ b/vcs2l/clients/git.py
@@ -25,7 +25,10 @@ class GitClient(VcsClientBase):
 
     @staticmethod
     def is_repository(path):
-        return os.path.isdir(os.path.join(path, '.git'))
+        """Check if the given path is a git repository or a submodule."""
+        return os.path.isdir(os.path.join(path, '.git')) or os.path.isfile(
+            os.path.join(path, '.git')
+        )
 
     def __init__(self, path):
         super(GitClient, self).__init__(path)


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | [#272](https://github.com/dirk-thomas/vcstool/issues/272) |
| Primary OS tested on | Ubuntu |
| Is this a breaking change? | No |
| Does this PR contain [AI generated](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md) software? | No |

---

## Description of contribution in a few bullet points
* Since submodules have `.git` as a file instead of a folder, this change accounts for detecting it as a repository to clone into.

## Description of how this change was tested

* Initialise a submodule locally within the repository under a `temp` folder.
   ```bash
   mkdir temp && cd temp
   git submodule add https://github.com/dirk-thomas/vcstool.git
   ```

* Compare the contents of `repo.yaml` before and after this change:
   ```bash
   cd vcs2l
   vcs export --nested > repos.yaml
   ```

* Final result of the YAML file:
   ```yaml
   repositories:
     vcs2l:
       type: git
       url: git@github.com:ros-infrastructure/vcs2l.git
       version: leander-dsouza/add-submodule-support
     vcs2l/temp/vcstool:
       type: git
       url: https://github.com/dirk-thomas/vcstool.git
       version: daf389377310f7f31b2171f51a79af82c31bf3e2
   ```
   The submodule would not have been detected if this change were not present.

Signed-off-by: Leander Stephen Desouza [leanderdsouza1234@gmail.com](mailto:leanderdsouza1234@gmail.com)