### PR TITLE
Migrate subsection of vcstools' API for compatibility with bloom

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,11 +41,21 @@ jobs:
           brew install subversion mercurial
         if: matrix.os == 'macos-latest'
 
+      - name: Install dependencies (macOS)
+        run: |
+          brew install subversion mercurial breezy
+        if: matrix.os == 'macos-latest'
+
       - name: Install dependencies (Ubuntu)
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends subversion mercurial
+          sudo apt-get install -y --no-install-recommends subversion mercurial brz
         if: startsWith(matrix.os, 'ubuntu')
+
+      - name: Install breezy pip (Ubuntu 24.04)
+        run: |
+          python -m pip install --upgrade breezy  # Adds breezy to the PYTHONPATH
+        if: startsWith(matrix.os, 'ubuntu-24.04')
 
       - name: Test with pytest
         run: |

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -177,7 +177,7 @@ class StagedReposFile(unittest.TestCase):
 
 
 class StagedReposFile2(unittest.TestCase):
-    """Fixture for testing subversion and mercurial clients."""
+    """Fixture for testing subversion, mercurial, and bazaar clients."""
 
     _svn = which('svn')
     _svnadmin = which('svnadmin')
@@ -186,6 +186,11 @@ class StagedReposFile2(unittest.TestCase):
         **os.environ,
         'HGUSER': 'vcs2l',
         'EMAIL': 'vcs2l@example.com',
+    }
+    _bzr = which('bzr')
+    _bzr_env = {
+        **os.environ,
+        'BZR_EMAIL': 'vcs2l <vcs2l@example.com>',
     }
     _commit_date = '2005-01-01T00:00:00-06:00'
 
@@ -200,6 +205,8 @@ class StagedReposFile2(unittest.TestCase):
             raise unittest.SkipTest('`svnadmin` was not found')
         if not cls._hg:
             raise unittest.SkipTest('`hg` was not found')
+        if not cls._bzr:
+            raise unittest.SkipTest('`bzr` was not found')
         try:
             # check if the svn executable is usable (on macOS)
             # and not only exists to state that the program is not installed
@@ -243,9 +250,14 @@ class StagedReposFile2(unittest.TestCase):
         # Create the staged mercurial repository
         hgrepo_path = os.path.join(cls.temp_dir.name, 'hgrepo')
         os.mkdir(hgrepo_path)
+        shutil.copy(
+            os.path.join(os.path.dirname(os.path.dirname(__file__)), 'LICENSE'),
+            hgrepo_path,
+        )
         for command in (
             ('init', '.'),
             ('branch', '--quiet', 'stable'),
+            ('add', 'LICENSE'),
             ('commit', '-m', 'Initial commit', '-d', cls._commit_date),
             ('tag', '-d', cls._commit_date, '5.8'),
         ):
@@ -258,6 +270,29 @@ class StagedReposFile2(unittest.TestCase):
                 env=cls._hg_env,
             )
 
+        # Create the staged bazaar repository
+        bzrrepo_path = os.path.join(cls.temp_dir.name, 'bzrrepo')
+        os.mkdir(bzrrepo_path)
+        shutil.copy(
+            os.path.join(os.path.dirname(os.path.dirname(__file__)), 'LICENSE'),
+            bzrrepo_path,
+        )
+        for command in (
+            ('init', '.'),
+            ('add', 'LICENSE'),
+            ('commit', '-m', 'Initial commit'),
+        ):
+            subprocess.check_call(
+                [
+                    cls._bzr,
+                    *command,
+                ],
+                cwd=bzrrepo_path,
+                env=cls._bzr_env,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+
         # Populate the staged.repos file
         repos = {
             'hg/branch': {
@@ -268,7 +303,7 @@ class StagedReposFile2(unittest.TestCase):
             'hg/hash': {
                 'type': 'hg',
                 'url': to_file_url(hgrepo_path),
-                'version': '9bd654917508',
+                'version': '27ff6a32cacf',
             },
             'hg/tag': {
                 'type': 'hg',

--- a/test/test_bzr.py
+++ b/test/test_bzr.py
@@ -1,6 +1,7 @@
 """Integration tests for BzrClient class."""
 
 import os
+import tarfile
 import tempfile
 import unittest
 
@@ -56,6 +57,68 @@ class TestCheckout(unittest.TestCase):
         # Verify the error message mentions the path
         self.assertIn(self.repo_path, str(context.exception))
         self.assertIn('Target path exists and is not empty', str(context.exception))
+
+
+class TestExportRepository(unittest.TestCase):
+    """Integration tests for BzrClient _export_repository functionality."""
+
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+        self.repo_path = os.path.join(self.test_dir, 'test_repo')
+        self.export_path = os.path.join(self.test_dir, 'export_test')
+        self.client = BzrClient(self.repo_path)
+        # Use a git repository instead of launchpad for future-proofing
+        self.repo_url = 'https://github.com/octocat/Hello-World.git'
+
+    def tearDown(self):
+        if os.path.exists(self.test_dir):
+            rmtree(self.test_dir)
+
+    def test_export_repository(self):
+        """Test export repository."""
+        self.client.checkout(self.repo_url)
+
+        # Change to the repository directory for export
+        original_cwd = os.getcwd()
+        try:
+            os.chdir(self.repo_path)
+
+            # Test export with a specific revision
+            result = self.client._export_repository(None, self.export_path)
+            self.assertTrue(result, 'Export should return True on success')
+
+            archive_path = self.export_path + '.tar.gz'
+            self.assertTrue(
+                os.path.exists(archive_path), 'Archive file should be created'
+            )
+
+            # Verify the archive is a valid tar.gz file
+            with tarfile.open(archive_path, 'r:gz') as tar:
+                members = tar.getnames()
+                self.assertGreater(len(members), 0, 'Archive should contain files')
+
+        finally:
+            os.chdir(original_cwd)
+
+    def test_export_repository_git_version_unsupported(self):
+        """Test export repository with unsupported version for git repo."""
+        self.client.checkout(self.repo_url)
+
+        # Change to the repository directory for export
+        original_cwd = os.getcwd()
+        try:
+            os.chdir(self.repo_path)
+
+            # Test export with invalid version
+            result = self.client._export_repository('999999999', self.export_path)
+            self.assertFalse(result, 'Version is not supported for git repositories.')
+
+            archive_path = self.export_path + '.tar.gz'
+            self.assertFalse(
+                os.path.exists(archive_path), 'Archive should not be created on failure'
+            )
+        finally:
+            os.chdir(original_cwd)
 
 
 if __name__ == '__main__':

--- a/test/test_bzr.py
+++ b/test/test_bzr.py
@@ -1,0 +1,62 @@
+"""Integration tests for BzrClient class."""
+
+import os
+import tempfile
+import unittest
+
+from vcs2l.clients.bzr import BzrClient
+from vcs2l.util import rmtree
+
+
+class TestCheckout(unittest.TestCase):
+    """Simple integration tests for BzrClient checkout functionality."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.test_dir = tempfile.mkdtemp()
+        self.repo_link = 'https://github.com/octocat/Hello-World.git'
+        self.repo_path = os.path.join(self.test_dir, 'test_repo')
+
+    def tearDown(self):
+        """Clean up after tests."""
+        if os.path.exists(self.test_dir):
+            rmtree(self.test_dir)
+
+    def test_checkout_repository(self):
+        """Test checkout with a valid repository URL."""
+        client = BzrClient(self.repo_path)
+        result = client.checkout(self.repo_link)
+
+        self.assertTrue(result)
+        self.assertTrue(os.path.exists(self.repo_path))
+
+    def test_checkout_invalid_url(self):
+        """Test checkout with invalid URL raises ValueError."""
+        client = BzrClient(self.repo_path)
+
+        with self.assertRaises(ValueError):
+            client.checkout(None)
+
+        with self.assertRaises(ValueError):
+            client.checkout('')
+
+    def test_checkout_existing_directory_fails(self):
+        """Test checkout fails when directory already exists with content."""
+        # Create the target directory and put a file in it
+        os.makedirs(self.repo_path, exist_ok=True)
+        test_file = os.path.join(self.repo_path, 'existing_file.txt')
+        with open(test_file, 'w', encoding='utf-8') as f:
+            f.write('This file already exists')
+
+        client = BzrClient(self.repo_path)
+
+        with self.assertRaises(RuntimeError) as context:
+            client.checkout(self.repo_link)
+
+        # Verify the error message mentions the path
+        self.assertIn(self.repo_path, str(context.exception))
+        self.assertIn('Target path exists and is not empty', str(context.exception))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_bzr.py
+++ b/test/test_bzr.py
@@ -1,18 +1,18 @@
 """Integration tests for BzrClient class."""
 
 import os
-import sys
 import tarfile
 import tempfile
 import unittest
+from shutil import which
 
 from vcs2l.clients.bzr import BzrClient
 from vcs2l.util import rmtree
 
-windows = sys.platform.startswith('win')
+bzr = which('bzr')
 
 
-@unittest.skipIf(windows, 'Breezy not supported on Windows')
+@unittest.skipIf(not bzr, '`bzr` was not found')
 class TestCheckout(unittest.TestCase):
     """Simple integration tests for BzrClient checkout functionality."""
 
@@ -63,7 +63,7 @@ class TestCheckout(unittest.TestCase):
         self.assertIn('Target path exists and is not empty', str(context.exception))
 
 
-@unittest.skipIf(windows, 'Breezy not supported on Windows')
+@unittest.skipIf(not bzr, '`bzr` was not found')
 class TestExportRepository(unittest.TestCase):
     """Integration tests for BzrClient _export_repository functionality."""
 

--- a/test/test_bzr.py
+++ b/test/test_bzr.py
@@ -65,7 +65,7 @@ class TestCheckout(unittest.TestCase):
 
 @unittest.skipIf(not bzr, '`bzr` was not found')
 class TestExportRepository(unittest.TestCase):
-    """Integration tests for BzrClient _export_repository functionality."""
+    """Integration tests for BzrClient export_repository functionality."""
 
     def setUp(self):
         self.test_dir = tempfile.mkdtemp()
@@ -89,7 +89,7 @@ class TestExportRepository(unittest.TestCase):
             os.chdir(self.repo_path)
 
             # Test export with a specific revision
-            result = self.client._export_repository(None, self.export_path)
+            result = self.client.export_repository(None, self.export_path)
             self.assertTrue(result, 'Export should return True on success')
 
             archive_path = self.export_path + '.tar.gz'
@@ -115,7 +115,7 @@ class TestExportRepository(unittest.TestCase):
             os.chdir(self.repo_path)
 
             # Test export with invalid version
-            result = self.client._export_repository('999999999', self.export_path)
+            result = self.client.export_repository('999999999', self.export_path)
             self.assertFalse(result, 'Version is not supported for git repositories.')
 
             archive_path = self.export_path + '.tar.gz'

--- a/test/test_bzr.py
+++ b/test/test_bzr.py
@@ -1,6 +1,7 @@
 """Integration tests for BzrClient class."""
 
 import os
+import sys
 import tarfile
 import tempfile
 import unittest
@@ -8,7 +9,10 @@ import unittest
 from vcs2l.clients.bzr import BzrClient
 from vcs2l.util import rmtree
 
+windows = sys.platform.startswith('win')
 
+
+@unittest.skipIf(windows, 'Breezy not supported on Windows')
 class TestCheckout(unittest.TestCase):
     """Simple integration tests for BzrClient checkout functionality."""
 
@@ -59,6 +63,7 @@ class TestCheckout(unittest.TestCase):
         self.assertIn('Target path exists and is not empty', str(context.exception))
 
 
+@unittest.skipIf(windows, 'Breezy not supported on Windows')
 class TestExportRepository(unittest.TestCase):
     """Integration tests for BzrClient _export_repository functionality."""
 

--- a/test/test_bzr.py
+++ b/test/test_bzr.py
@@ -1,129 +1,132 @@
-"""Integration tests for BzrClient class."""
+"""Tests for BzrClient."""
 
 import os
 import tarfile
-import tempfile
 import unittest
-from shutil import which
+from tempfile import TemporaryDirectory
 
 from vcs2l.clients.bzr import BzrClient
-from vcs2l.util import rmtree
 
-bzr = which('bzr')
-
-
-@unittest.skipIf(not bzr, '`bzr` was not found')
-class TestCheckout(unittest.TestCase):
-    """Simple integration tests for BzrClient checkout functionality."""
-
-    def setUp(self):
-        """Set up test fixtures."""
-        self.test_dir = tempfile.mkdtemp()
-        self.repo_link = 'https://github.com/octocat/Hello-World.git'
-        self.repo_path = os.path.join(self.test_dir, 'test_repo')
-
-    def tearDown(self):
-        """Clean up after tests."""
-        if os.path.exists(self.test_dir):
-            rmtree(self.test_dir)
-
-    def test_checkout_repository(self):
-        """Test checkout with a valid repository URL."""
-        client = BzrClient(self.repo_path)
-        result = client.checkout(self.repo_link)
-
-        self.assertTrue(result)
-        self.assertTrue(os.path.exists(self.repo_path))
-
-    def test_checkout_invalid_url(self):
-        """Test checkout with invalid URL raises ValueError."""
-        client = BzrClient(self.repo_path)
-
-        with self.assertRaises(ValueError):
-            client.checkout(None)
-
-        with self.assertRaises(ValueError):
-            client.checkout('')
-
-    def test_checkout_existing_directory_fails(self):
-        """Test checkout fails when directory already exists with content."""
-        # Create the target directory and put a file in it
-        os.makedirs(self.repo_path, exist_ok=True)
-        test_file = os.path.join(self.repo_path, 'existing_file.txt')
-        with open(test_file, 'w', encoding='utf-8') as f:
-            f.write('This file already exists')
-
-        client = BzrClient(self.repo_path)
-
-        with self.assertRaises(RuntimeError) as context:
-            client.checkout(self.repo_link)
-
-        # Verify the error message mentions the path
-        self.assertIn(self.repo_path, str(context.exception))
-        self.assertIn('Target path exists and is not empty', str(context.exception))
+from . import StagedReposFile2, to_file_url
 
 
-@unittest.skipIf(not bzr, '`bzr` was not found')
-class TestExportRepository(unittest.TestCase):
-    """Integration tests for BzrClient export_repository functionality."""
+class TestBzrCheckout(StagedReposFile2):
+    """Test BzrClient.checkout using the staged bzr repository."""
 
-    def setUp(self):
-        self.test_dir = tempfile.mkdtemp()
-        self.repo_path = os.path.join(self.test_dir, 'test_repo')
-        self.export_path = os.path.join(self.test_dir, 'export_test')
-        self.client = BzrClient(self.repo_path)
-        # Use a git repository instead of launchpad for future-proofing
-        self.repo_url = 'https://github.com/octocat/Hello-World.git'
+    def test_default_branch(self):
+        """Checkout without a version branches the entire repository."""
+        with TemporaryDirectory(suffix='.bzr_checkout') as tmp:
+            dest = os.path.join(tmp, 'repo')
+            client = BzrClient(dest)
+            url = to_file_url(os.path.join(self.temp_dir.name, 'bzrrepo'))
 
-    def tearDown(self):
-        if os.path.exists(self.test_dir):
-            rmtree(self.test_dir)
+            result = client.checkout(url)
+            self.assertTrue(result)
+            self.assertTrue(os.path.isdir(os.path.join(dest, '.bzr')))
+            self.assertTrue(os.path.isfile(os.path.join(dest, 'LICENSE')))
 
-    def test_export_repository(self):
-        """Test export repository."""
-        self.client.checkout(self.repo_url)
+    def test_specific_hash(self):
+        """Checkout at revision 1."""
+        with TemporaryDirectory(suffix='.bzr_checkout') as tmp:
+            dest = os.path.join(tmp, 'repo')
+            client = BzrClient(dest)
+            url = to_file_url(os.path.join(self.temp_dir.name, 'bzrrepo'))
 
-        # Change to the repository directory for export
-        original_cwd = os.getcwd()
-        try:
-            os.chdir(self.repo_path)
+            result = client.checkout(url, version='1')
+            self.assertTrue(result)
+            self.assertTrue(os.path.isdir(os.path.join(dest, '.bzr')))
+            self.assertTrue(os.path.isfile(os.path.join(dest, 'LICENSE')))
 
-            # Test export with a specific revision
-            result = self.client.export_repository(None, self.export_path)
-            self.assertTrue(result, 'Export should return True on success')
+    def test_nonempty_dir(self):
+        """Checkout into a non-empty directory should raise RuntimeError."""
+        with TemporaryDirectory(suffix='.bzr_checkout') as tmp:
+            dest = os.path.join(tmp, 'repo')
+            os.makedirs(dest)
+            with open(os.path.join(dest, 'blocker.txt'), 'w', encoding='utf-8') as f:
+                f.write('occupied')
 
-            archive_path = self.export_path + '.tar.gz'
-            self.assertTrue(
-                os.path.exists(archive_path), 'Archive file should be created'
-            )
+            client = BzrClient(dest)
+            url = to_file_url(os.path.join(self.temp_dir.name, 'bzrrepo'))
 
-            # Verify the archive is a valid tar.gz file
-            with tarfile.open(archive_path, 'r:gz') as tar:
-                members = tar.getnames()
-                self.assertGreater(len(members), 0, 'Archive should contain files')
+            with self.assertRaises(RuntimeError):
+                client.checkout(url)
 
-        finally:
-            os.chdir(original_cwd)
+    def test_invalid_version(self):
+        """Checkout with a non-existent revision should return False."""
+        with TemporaryDirectory(suffix='.bzr_checkout') as tmp:
+            dest = os.path.join(tmp, 'repo')
+            client = BzrClient(dest)
+            url = to_file_url(os.path.join(self.temp_dir.name, 'bzrrepo'))
 
-    def test_export_repository_git_version_unsupported(self):
-        """Test export repository with unsupported version for git repo."""
-        self.client.checkout(self.repo_url)
+            result = client.checkout(url, version='9999')
+            self.assertFalse(result)
 
-        # Change to the repository directory for export
-        original_cwd = os.getcwd()
-        try:
-            os.chdir(self.repo_path)
+    def test_invalid_url(self):
+        """Checkout from a non-existent local repository should return False."""
+        with TemporaryDirectory(suffix='.bzr_checkout') as tmp:
+            dest = os.path.join(tmp, 'repo')
+            client = BzrClient(dest)
+            url = to_file_url(os.path.join(self.temp_dir.name, 'does-not-exist'))
 
-            # Test export with invalid version
-            result = self.client.export_repository('999999999', self.export_path)
-            self.assertFalse(result, 'Version is not supported for git repositories.')
+            result = client.checkout(url)
+            self.assertFalse(result)
 
-            archive_path = self.export_path + '.tar.gz'
-            self.assertFalse(
-                os.path.exists(archive_path), 'Archive should not be created on failure'
-            )
-        finally:
-            os.chdir(original_cwd)
+
+class TestBzrExportRepository(StagedReposFile2):
+    """Test BzrClient.export_repository using the staged bzr repository."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls._export_dir = TemporaryDirectory(suffix='.bzr_export')
+        cls._export_path = os.path.join(cls._export_dir.name, 'repo')
+        client = BzrClient(cls._export_path)
+        url = to_file_url(os.path.join(cls.temp_dir.name, 'bzrrepo'))
+        assert client.checkout(url), 'Failed to branch staged bzr repo'
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._export_dir.cleanup()
+        super().tearDownClass()
+
+    def test_creates_tarball(self):
+        """export_repository should create a .tar.gz archive."""
+        with TemporaryDirectory(suffix='.bzr_export') as tmp:
+            basepath = os.path.join(tmp, 'export')
+            client = BzrClient(self._export_path)
+
+            result = client.export_repository('1', basepath)
+            self.assertTrue(result)
+            self.assertTrue(os.path.isfile(basepath + '.tar.gz'))
+
+            with tarfile.open(basepath + '.tar.gz', 'r:gz') as tar:
+                names = tar.getnames()
+                self.assertTrue(len(names) > 0)
+
+    def test_contains_license(self):
+        """Exported archive should contain LICENSE."""
+        with TemporaryDirectory(suffix='.bzr_export') as tmp:
+            basepath = os.path.join(tmp, 'export')
+            client = BzrClient(self._export_path)
+
+            result = client.export_repository('1', basepath)
+            self.assertTrue(result)
+
+            with tarfile.open(basepath + '.tar.gz', 'r:gz') as tar:
+                names = tar.getnames()
+                self.assertTrue(
+                    any('LICENSE' in n for n in names),
+                    f'LICENSE not found in archive: {names}',
+                )
+
+    def test_invalid_version(self):
+        """export_repository with a bad revision should return False."""
+        with TemporaryDirectory(suffix='.bzr_export') as tmp:
+            basepath = os.path.join(tmp, 'export')
+            client = BzrClient(self._export_path)
+
+            result = client.export_repository('9999', basepath)
+            self.assertFalse(result)
 
 
 if __name__ == '__main__':

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -1,0 +1,63 @@
+"""Unit tests for GitClient checkout functionality"""
+
+import os
+import tempfile
+import unittest
+
+from vcs2l.clients.git import GitClient
+from vcs2l.util import rmtree
+
+
+class TestCheckout(unittest.TestCase):
+    """Test cases for GitClient checkout method"""
+
+    def setUp(self):
+        # Create a temporary directory for testing
+        self.test_dir = tempfile.mkdtemp()
+        self.repo_path = os.path.join(self.test_dir, 'test_repo')
+
+    def tearDown(self):
+        if os.path.exists(self.test_dir):
+            rmtree(self.test_dir)
+
+    def test_checkout_specific_branch(self):
+        """Test checking out a specific branch"""
+        client = GitClient(self.repo_path)
+
+        url = 'https://github.com/octocat/Hello-World.git'
+        success = client.checkout(url, version='test', shallow=True)
+
+        self.assertTrue(success, 'Checkout should succeed')
+        self.assertTrue(os.path.exists(self.repo_path), 'Repo directory should exist')
+        self.assertTrue(
+            os.path.isdir(os.path.join(self.repo_path, '.git')),
+            'Should be a git repository',
+        )
+
+    def test_checkout_nonexistent_repo(self):
+        """Test checking out a non-existent repository should fail"""
+        client = GitClient(self.repo_path)
+
+        url = 'https://github.com/this/repo/does/not/exist.git'
+        success = client.checkout(url, verbose=True)
+
+        self.assertFalse(success, 'Checkout should fail for non-existent repo')
+
+    def test_checkout_to_existing_directory(self):
+        """Test checking out to a non-empty directory should fail"""
+        # Create a non-empty directory
+        os.makedirs(self.repo_path)
+        with open(
+            os.path.join(self.repo_path, 'existing_file.txt'), 'w', encoding='utf-8'
+        ) as f:
+            f.write('This file already exists')
+
+        client = GitClient(self.repo_path)
+        url = 'https://github.com/octocat/Hello-World.git'
+        success = client.checkout(url)
+
+        self.assertFalse(success, 'Checkout should fail for non-empty directory')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -1,6 +1,7 @@
 """Unit tests for GitClient checkout functionality"""
 
 import os
+import tarfile
 import tempfile
 import unittest
 
@@ -57,6 +58,87 @@ class TestCheckout(unittest.TestCase):
         success = client.checkout(url)
 
         self.assertFalse(success, 'Checkout should fail for non-empty directory')
+
+
+class TestExportRepository(unittest.TestCase):
+    """Test cases for GitClient export_repository method"""
+
+    def setUp(self):
+        # Create a temporary directory for testing
+        self.test_dir = tempfile.mkdtemp()
+        self.repo_path = os.path.join(self.test_dir, 'test_repo')
+        self.export_dir = os.path.join(self.test_dir, 'exports')
+        os.makedirs(self.export_dir, exist_ok=True)
+
+        self.test_repo_url = 'https://github.com/octocat/Hello-World.git'
+        self.client = GitClient(self.repo_path)
+
+    def tearDown(self):
+        if os.path.exists(self.test_dir):
+            rmtree(self.test_dir)
+
+    def test_export_specific_branch(self):
+        """Test exporting the repository at a specific branch"""
+        success = self.client.checkout(self.test_repo_url, version='test')
+
+        if not success:
+            self.fail('Failed to clone test repository')
+
+        basepath = os.path.join(self.export_dir, 'repo_export')
+        filepath = self.client.export_repository('test', basepath)
+
+        self.assertTrue(os.path.exists(filepath), 'Export file should exist')
+        self.assertGreater(
+            os.path.getsize(filepath), 0, 'Export file should not be empty'
+        )
+        # Verify it's a valid tar.gz file
+        try:
+            if filepath and isinstance(filepath, str):
+                with tarfile.open(filepath, 'r:gz') as tar:
+                    members = tar.getnames()
+                    self.assertIn('README', members, 'Should contain README file')
+            else:
+                self.fail('Exported file path is invalid')
+        except tarfile.ReadError:
+            self.fail('Exported file should be a valid tar.gz archive')
+
+    def test_export_with_local_changes_uses_temp_dir(self):
+        """Test that export uses temp directory when there are local changes"""
+        # First clone the repository
+        success = self.client.checkout(self.test_repo_url)
+        if not success:
+            self.fail('Failed to clone test repository')
+
+        # Create a local change
+        test_file = os.path.join(self.repo_path, 'test_change.txt')
+        with open(test_file, 'w', encoding='utf-8') as f:
+            f.write('test change')
+
+        basepath = os.path.join(self.export_dir, 'local_changes_test')
+        filepath = self.client.export_repository(None, basepath)
+
+        self.assertIsNotNone(filepath, 'Export should succeed even with local changes')
+        self.assertTrue(os.path.exists(filepath), 'Export file should exist')
+        self.assertGreater(
+            os.path.getsize(filepath), 0, 'Export file should not be empty'
+        )
+
+        # Clean up
+        os.remove(test_file)
+
+    def test_export_invalid_branch(self):
+        """Test exporting a non-existent branch should fail gracefully"""
+        success = self.client.checkout(self.test_repo_url)
+
+        if not success:
+            self.fail('Failed to clone test repository')
+
+        basepath = os.path.join(self.export_dir, 'nonexistent_export')
+        result = self.client.export_repository('nonexistent-branch-12345', basepath)
+
+        self.assertEqual(
+            result, False, 'Export should return False for non-existent ref'
+        )
 
 
 if __name__ == '__main__':

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -58,7 +58,7 @@ class TestGitCheckout(StagedReposFile):
             self.assertTrue(os.path.isdir(os.path.join(dest, '.git')))
 
     def test_nonempty_dir(self):
-        """Checkout into a non-empty directory should return False."""
+        """Checkout into a non-empty directory should raise RuntimeError."""
         with TemporaryDirectory(suffix='.git_checkout') as tmp:
             dest = os.path.join(tmp, 'repo')
             os.makedirs(dest)
@@ -69,8 +69,8 @@ class TestGitCheckout(StagedReposFile):
             client = GitClient(dest)
             url = to_file_url(os.path.join(self.temp_dir.name, 'gitrepo'))
 
-            result = client.checkout(url)
-            self.assertFalse(result)
+            with self.assertRaises(RuntimeError):
+                client.checkout(url)
 
     def test_invalid_version(self):
         """Checkout with a non-existent version should return False."""

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -1,144 +1,154 @@
-"""Unit tests for GitClient checkout functionality"""
+"""Tests for Git Client."""
 
 import os
 import tarfile
-import tempfile
 import unittest
+from tempfile import TemporaryDirectory
 
 from vcs2l.clients.git import GitClient
-from vcs2l.util import rmtree
+
+from . import StagedReposFile, to_file_url
 
 
-class TestCheckout(unittest.TestCase):
-    """Test cases for GitClient checkout method"""
+class TestGitCheckout(StagedReposFile):
+    """Test GitClient.checkout using the staged git repository."""
 
-    def setUp(self):
-        # Create a temporary directory for testing
-        self.test_dir = tempfile.mkdtemp()
-        self.repo_path = os.path.join(self.test_dir, 'test_repo')
+    def test_default_branch(self):
+        """Checkout without a version gets the default branch."""
+        with TemporaryDirectory(suffix='.git_checkout') as tmp:
+            dest = os.path.join(tmp, 'repo')
+            client = GitClient(dest)
+            url = to_file_url(os.path.join(self.temp_dir.name, 'gitrepo'))
 
-    def tearDown(self):
-        if os.path.exists(self.test_dir):
-            rmtree(self.test_dir)
+            result = client.checkout(url)
+            self.assertTrue(result)
+            self.assertTrue(os.path.isdir(os.path.join(dest, '.git')))
 
-    def test_checkout_specific_branch(self):
-        """Test checking out a specific branch"""
-        client = GitClient(self.repo_path)
+    def test_specific_branch(self):
+        """Checkout the main branch by name."""
+        with TemporaryDirectory(suffix='.git_checkout') as tmp:
+            dest = os.path.join(tmp, 'repo')
+            client = GitClient(dest)
+            url = to_file_url(os.path.join(self.temp_dir.name, 'gitrepo'))
 
-        url = 'https://github.com/octocat/Hello-World.git'
-        success = client.checkout(url, version='test', shallow=True)
+            result = client.checkout(url, version='main')
+            self.assertTrue(result)
+            self.assertTrue(os.path.isdir(os.path.join(dest, '.git')))
 
-        self.assertTrue(success, 'Checkout should succeed')
-        self.assertTrue(os.path.exists(self.repo_path), 'Repo directory should exist')
-        self.assertTrue(
-            os.path.isdir(os.path.join(self.repo_path, '.git')),
-            'Should be a git repository',
-        )
+    def test_specific_tag(self):
+        """Checkout a specific tag."""
+        with TemporaryDirectory(suffix='.git_checkout') as tmp:
+            dest = os.path.join(tmp, 'repo')
+            client = GitClient(dest)
+            url = to_file_url(os.path.join(self.temp_dir.name, 'gitrepo'))
 
-    def test_checkout_nonexistent_repo(self):
-        """Test checking out a non-existent repository should fail"""
-        client = GitClient(self.repo_path)
+            result = client.checkout(url, version='0.1.26')
+            self.assertTrue(result)
+            self.assertTrue(os.path.isdir(os.path.join(dest, '.git')))
 
-        url = 'https://github.com/this/repo/does/not/exist.git'
-        success = client.checkout(url, verbose=True)
+    def test_specific_hash(self):
+        """Checkout a specific commit hash."""
+        with TemporaryDirectory(suffix='.git_checkout') as tmp:
+            dest = os.path.join(tmp, 'repo')
+            client = GitClient(dest)
+            url = to_file_url(os.path.join(self.temp_dir.name, 'gitrepo'))
 
-        self.assertFalse(success, 'Checkout should fail for non-existent repo')
+            result = client.checkout(url, version=self._tag_hashes['1.1.3'])
+            self.assertTrue(result)
+            self.assertTrue(os.path.isdir(os.path.join(dest, '.git')))
 
-    def test_checkout_to_existing_directory(self):
-        """Test checking out to a non-empty directory should fail"""
-        # Create a non-empty directory
-        os.makedirs(self.repo_path)
-        with open(
-            os.path.join(self.repo_path, 'existing_file.txt'), 'w', encoding='utf-8'
-        ) as f:
-            f.write('This file already exists')
+    def test_nonempty_dir(self):
+        """Checkout into a non-empty directory should return False."""
+        with TemporaryDirectory(suffix='.git_checkout') as tmp:
+            dest = os.path.join(tmp, 'repo')
+            os.makedirs(dest)
+            # Place a file so the directory is non-empty
+            with open(os.path.join(dest, 'blocker.txt'), 'w', encoding='utf-8') as f:
+                f.write('occupied')
 
-        client = GitClient(self.repo_path)
-        url = 'https://github.com/octocat/Hello-World.git'
-        success = client.checkout(url)
+            client = GitClient(dest)
+            url = to_file_url(os.path.join(self.temp_dir.name, 'gitrepo'))
 
-        self.assertFalse(success, 'Checkout should fail for non-empty directory')
+            result = client.checkout(url)
+            self.assertFalse(result)
+
+    def test_invalid_version(self):
+        """Checkout with a non-existent version should return False."""
+        with TemporaryDirectory(suffix='.git_checkout') as tmp:
+            dest = os.path.join(tmp, 'repo')
+            client = GitClient(dest)
+            url = to_file_url(os.path.join(self.temp_dir.name, 'gitrepo'))
+
+            result = client.checkout(url, version='nonexistent-branch-xyz')
+            self.assertFalse(result)
+
+    def test_invalid_url(self):
+        """Checkout from a non-existent local repository should return False."""
+        with TemporaryDirectory(suffix='.git_checkout') as tmp:
+            dest = os.path.join(tmp, 'repo')
+            client = GitClient(dest)
+            url = to_file_url(os.path.join(self.temp_dir.name, 'does-not-exist'))
+
+            result = client.checkout(url)
+            self.assertFalse(result)
 
 
-class TestExportRepository(unittest.TestCase):
-    """Test cases for GitClient export_repository method"""
+class TestGitExportRepository(StagedReposFile):
+    """Test GitClient.export_repository using the staged git repository."""
 
-    def setUp(self):
-        # Create a temporary directory for testing
-        self.test_dir = tempfile.mkdtemp()
-        self.repo_path = os.path.join(self.test_dir, 'test_repo')
-        self.export_dir = os.path.join(self.test_dir, 'exports')
-        os.makedirs(self.export_dir, exist_ok=True)
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # Clone the staged repo so we have a working git directory
+        cls._export_dir = TemporaryDirectory(suffix='.git_export')
+        cls._export_path = os.path.join(cls._export_dir.name, 'repo')
+        client = GitClient(cls._export_path)
+        url = to_file_url(os.path.join(cls.temp_dir.name, 'gitrepo'))
+        assert client.checkout(url, version='0.1.27'), 'Failed to clone staged repo'
 
-        self.test_repo_url = 'https://github.com/octocat/Hello-World.git'
-        self.client = GitClient(self.repo_path)
+    @classmethod
+    def tearDownClass(cls):
+        cls._export_dir.cleanup()
+        super().tearDownClass()
 
-    def tearDown(self):
-        if os.path.exists(self.test_dir):
-            rmtree(self.test_dir)
+    def test_creates_tarball(self):
+        """export_repository should create a .tar.gz archive."""
+        with TemporaryDirectory(suffix='.git_export') as tmp:
+            basepath = os.path.join(tmp, 'export')
+            client = GitClient(self._export_path)
 
-    def test_export_specific_branch(self):
-        """Test exporting the repository at a specific branch"""
-        success = self.client.checkout(self.test_repo_url, version='test')
+            result = client.export_repository('0.1.27', basepath)
+            self.assertTrue(result)
+            self.assertTrue(os.path.isfile(basepath + '.tar.gz'))
 
-        if not success:
-            self.fail('Failed to clone test repository')
+            with tarfile.open(basepath + '.tar.gz', 'r:gz') as tar:
+                names = tar.getnames()
+                self.assertTrue(len(names) > 0)
 
-        basepath = os.path.join(self.export_dir, 'repo_export')
-        filepath = self.client.export_repository('test', basepath)
+    def test_contains_license(self):
+        """Exported archive at a tag after LICENSE merge should contain LICENSE."""
+        with TemporaryDirectory(suffix='.git_export') as tmp:
+            basepath = os.path.join(tmp, 'export')
+            client = GitClient(self._export_path)
 
-        self.assertTrue(os.path.exists(filepath), 'Export file should exist')
-        self.assertGreater(
-            os.path.getsize(filepath), 0, 'Export file should not be empty'
-        )
-        # Verify it's a valid tar.gz file
-        try:
-            if filepath and isinstance(filepath, str):
-                with tarfile.open(filepath, 'r:gz') as tar:
-                    members = tar.getnames()
-                    self.assertIn('README', members, 'Should contain README file')
-            else:
-                self.fail('Exported file path is invalid')
-        except tarfile.ReadError:
-            self.fail('Exported file should be a valid tar.gz archive')
+            result = client.export_repository('0.1.27', basepath)
+            self.assertTrue(result)
 
-    def test_export_with_local_changes_uses_temp_dir(self):
-        """Test that export uses temp directory when there are local changes"""
-        # First clone the repository
-        success = self.client.checkout(self.test_repo_url)
-        if not success:
-            self.fail('Failed to clone test repository')
+            with tarfile.open(basepath + '.tar.gz', 'r:gz') as tar:
+                names = tar.getnames()
+                self.assertTrue(
+                    any('LICENSE' in n for n in names),
+                    f'LICENSE not found in archive: {names}',
+                )
 
-        # Create a local change
-        test_file = os.path.join(self.repo_path, 'test_change.txt')
-        with open(test_file, 'w', encoding='utf-8') as f:
-            f.write('test change')
+    def test_invalid_version(self):
+        """export_repository with a bad ref should return False."""
+        with TemporaryDirectory(suffix='.git_export') as tmp:
+            basepath = os.path.join(tmp, 'export')
+            client = GitClient(self._export_path)
 
-        basepath = os.path.join(self.export_dir, 'local_changes_test')
-        filepath = self.client.export_repository(None, basepath)
-
-        self.assertIsNotNone(filepath, 'Export should succeed even with local changes')
-        self.assertTrue(os.path.exists(filepath), 'Export file should exist')
-        self.assertGreater(
-            os.path.getsize(filepath), 0, 'Export file should not be empty'
-        )
-
-        # Clean up
-        os.remove(test_file)
-
-    def test_export_invalid_branch(self):
-        """Test exporting a non-existent branch should fail gracefully"""
-        success = self.client.checkout(self.test_repo_url)
-
-        if not success:
-            self.fail('Failed to clone test repository')
-
-        basepath = os.path.join(self.export_dir, 'nonexistent_export')
-        result = self.client.export_repository('nonexistent-branch-12345', basepath)
-
-        self.assertEqual(
-            result, False, 'Export should return False for non-existent ref'
-        )
+            result = client.export_repository('nonexistent-branch-xyz', basepath)
+            self.assertFalse(result)
 
 
 if __name__ == '__main__':

--- a/test/test_hg.py
+++ b/test/test_hg.py
@@ -64,7 +64,7 @@ class TestCheckout(unittest.TestCase):
 
 @unittest.skipIf(not hg, '`hg` was not found')
 class TestExportRepository(unittest.TestCase):
-    """Integration tests for HgClient _export_repository functionality."""
+    """Integration tests for HgClient export_repository functionality."""
 
     def setUp(self):
         """Set up test fixtures for each test"""
@@ -97,7 +97,7 @@ class TestExportRepository(unittest.TestCase):
 
     def test_export_repository_specific_revision(self):
         """Test exporting a specific revision"""
-        result = self.hg_client._export_repository('1', self.export_base_path)
+        result = self.hg_client.export_repository('1', self.export_base_path)
         self.assertTrue(result, "Export should succeed for revision '1'")
 
         # Verify files were created correctly
@@ -108,7 +108,7 @@ class TestExportRepository(unittest.TestCase):
         """Test exporting with an invalid revision"""
         invalid_revision = 'nonexistent123456789'
 
-        result = self.hg_client._export_repository(
+        result = self.hg_client.export_repository(
             invalid_revision, self.export_base_path
         )
         self.assertFalse(result, 'Export should fail for invalid revision')

--- a/test/test_hg.py
+++ b/test/test_hg.py
@@ -1,0 +1,65 @@
+"""Integration tests for HgClient checkout functionality"""
+
+import os
+import tempfile
+import unittest
+from shutil import which
+
+from vcs2l.clients.hg import HgClient
+from vcs2l.util import rmtree
+
+hg = which('hg')
+
+
+@unittest.skipIf(not hg, '`hg` was not found')
+class TestCheckout(unittest.TestCase):
+    """Test cases for HgClient checkout method."""
+
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+        self.repo_url = 'https://www.mercurial-scm.org/repo/hello'
+        self.repo_path = os.path.join(self.test_dir, 'test_repo')
+
+    def tearDown(self):
+        if os.path.exists(self.test_dir):
+            rmtree(self.test_dir)
+
+    def test_checkout_with_version(self):
+        """Test checkout with a specific version/revision."""
+        client = HgClient(self.repo_path)
+        result = client.checkout(self.repo_url, version='1')
+
+        self.assertTrue(result, 'Checkout with version should return True on success')
+        self.assertTrue(
+            os.path.exists(self.repo_path), 'Repository directory should be created'
+        )
+        self.assertTrue(
+            HgClient.is_repository(self.repo_path),
+            'Should create valid Mercurial repository',
+        )
+
+    def test_checkout_invalid_url(self):
+        """Test checkout with an invalid URL."""
+        client = HgClient(self.repo_path)
+        result = client.checkout('https://invalid-url-for-testing.com/repo')
+
+        self.assertFalse(result, 'Checkout with invalid URL should return False')
+
+    def test_checkout_existing_directory(self):
+        """Test checkout fails when directory already exists with content."""
+        # Create the target directory and put a file in it
+        os.makedirs(self.repo_path, exist_ok=True)
+        test_file = os.path.join(self.repo_path, 'existing_file.txt')
+        with open(test_file, 'w', encoding='utf-8') as f:
+            f.write('This file already exists')
+
+        client = HgClient(self.repo_path)
+        result = client.checkout(self.repo_url)
+
+        self.assertFalse(
+            result, 'Checkout should return False when directory exists with content'
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_hg.py
+++ b/test/test_hg.py
@@ -1,6 +1,7 @@
 """Integration tests for HgClient checkout functionality"""
 
 import os
+import subprocess
 import tempfile
 import unittest
 from shutil import which
@@ -59,6 +60,63 @@ class TestCheckout(unittest.TestCase):
         self.assertFalse(
             result, 'Checkout should return False when directory exists with content'
         )
+
+
+@unittest.skipIf(not hg, '`hg` was not found')
+class TestExportRepository(unittest.TestCase):
+    """Integration tests for HgClient _export_repository functionality."""
+
+    def setUp(self):
+        """Set up test fixtures for each test"""
+        self.test_dir = tempfile.mkdtemp(prefix='hg_test_')
+        self.repo_path = os.path.join(self.test_dir, 'hello')
+        self.export_base_path = os.path.join(self.test_dir, 'exported_repo')
+        self.repo_url = 'https://www.mercurial-scm.org/repo/hello'
+
+        self.hg_client = HgClient(self.repo_path)
+
+        self._ensure_repo_cloned()
+
+    def tearDown(self):
+        """Clean up test fixtures"""
+        if os.path.exists(self.test_dir):
+            rmtree(self.test_dir)
+
+    def _ensure_repo_cloned(self):
+        """Ensure the test repository is cloned locally"""
+        if not os.path.exists(self.repo_path):
+            try:
+                subprocess.run(
+                    ['hg', 'clone', '--rev', 'tip', self.repo_url, self.repo_path],
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                )
+            except subprocess.CalledProcessError as e:
+                self.fail(f'Failed to clone repository: {e.stderr}')
+
+    def test_export_repository_specific_revision(self):
+        """Test exporting a specific revision"""
+        result = self.hg_client._export_repository('1', self.export_base_path)
+        self.assertTrue(result, "Export should succeed for revision '1'")
+
+        # Verify files were created correctly
+        tar_gz_path = self.export_base_path + '.tar.gz'
+        self.assertTrue(os.path.exists(tar_gz_path))
+
+    def test_export_repository_invalid_revision(self):
+        """Test exporting with an invalid revision"""
+        invalid_revision = 'nonexistent123456789'
+
+        result = self.hg_client._export_repository(
+            invalid_revision, self.export_base_path
+        )
+        self.assertFalse(result, 'Export should fail for invalid revision')
+
+        tar_gz_path = self.export_base_path + '.tar.gz'
+        tar_path = self.export_base_path + '.tar'
+        self.assertFalse(os.path.exists(tar_gz_path))
+        self.assertFalse(os.path.exists(tar_path))
 
 
 if __name__ == '__main__':

--- a/test/test_hg.py
+++ b/test/test_hg.py
@@ -1,122 +1,152 @@
-"""Integration tests for HgClient checkout functionality"""
+"""Tests for HgClient checkout and export_repository functionality."""
 
 import os
-import subprocess
-import tempfile
+import tarfile
 import unittest
-from shutil import which
+from tempfile import TemporaryDirectory
 
 from vcs2l.clients.hg import HgClient
-from vcs2l.util import rmtree
 
-hg = which('hg')
-
-
-@unittest.skipIf(not hg, '`hg` was not found')
-class TestCheckout(unittest.TestCase):
-    """Test cases for HgClient checkout method."""
-
-    def setUp(self):
-        self.test_dir = tempfile.mkdtemp()
-        self.repo_url = 'https://www.mercurial-scm.org/repo/hello'
-        self.repo_path = os.path.join(self.test_dir, 'test_repo')
-
-    def tearDown(self):
-        if os.path.exists(self.test_dir):
-            rmtree(self.test_dir)
-
-    def test_checkout_with_version(self):
-        """Test checkout with a specific version/revision."""
-        client = HgClient(self.repo_path)
-        result = client.checkout(self.repo_url, version='1')
-
-        self.assertTrue(result, 'Checkout with version should return True on success')
-        self.assertTrue(
-            os.path.exists(self.repo_path), 'Repository directory should be created'
-        )
-        self.assertTrue(
-            HgClient.is_repository(self.repo_path),
-            'Should create valid Mercurial repository',
-        )
-
-    def test_checkout_invalid_url(self):
-        """Test checkout with an invalid URL."""
-        client = HgClient(self.repo_path)
-        result = client.checkout('https://invalid-url-for-testing.com/repo')
-
-        self.assertFalse(result, 'Checkout with invalid URL should return False')
-
-    def test_checkout_existing_directory(self):
-        """Test checkout fails when directory already exists with content."""
-        # Create the target directory and put a file in it
-        os.makedirs(self.repo_path, exist_ok=True)
-        test_file = os.path.join(self.repo_path, 'existing_file.txt')
-        with open(test_file, 'w', encoding='utf-8') as f:
-            f.write('This file already exists')
-
-        client = HgClient(self.repo_path)
-        result = client.checkout(self.repo_url)
-
-        self.assertFalse(
-            result, 'Checkout should return False when directory exists with content'
-        )
+from . import StagedReposFile2, to_file_url
 
 
-@unittest.skipIf(not hg, '`hg` was not found')
-class TestExportRepository(unittest.TestCase):
-    """Integration tests for HgClient export_repository functionality."""
+class TestHgCheckout(StagedReposFile2):
+    """Test HgClient.checkout using the staged hg repository."""
 
-    def setUp(self):
-        """Set up test fixtures for each test"""
-        self.test_dir = tempfile.mkdtemp(prefix='hg_test_')
-        self.repo_path = os.path.join(self.test_dir, 'hello')
-        self.export_base_path = os.path.join(self.test_dir, 'exported_repo')
-        self.repo_url = 'https://www.mercurial-scm.org/repo/hello'
+    def test_default_branch(self):
+        """Checkout without a version clones the entire repository."""
+        with TemporaryDirectory(suffix='.hg_checkout') as tmp:
+            dest = os.path.join(tmp, 'repo')
+            client = HgClient(dest)
+            url = to_file_url(os.path.join(self.temp_dir.name, 'hgrepo'))
 
-        self.hg_client = HgClient(self.repo_path)
+            result = client.checkout(url)
+            self.assertTrue(result)
+            self.assertTrue(HgClient.is_repository(dest))
 
-        self._ensure_repo_cloned()
+    def test_specific_branch(self):
+        """Checkout a specific named branch."""
+        with TemporaryDirectory(suffix='.hg_checkout') as tmp:
+            dest = os.path.join(tmp, 'repo')
+            client = HgClient(dest)
+            url = to_file_url(os.path.join(self.temp_dir.name, 'hgrepo'))
 
-    def tearDown(self):
-        """Clean up test fixtures"""
-        if os.path.exists(self.test_dir):
-            rmtree(self.test_dir)
+            result = client.checkout(url, version='stable')
+            self.assertTrue(result)
+            self.assertTrue(HgClient.is_repository(dest))
 
-    def _ensure_repo_cloned(self):
-        """Ensure the test repository is cloned locally"""
-        if not os.path.exists(self.repo_path):
-            try:
-                subprocess.run(
-                    ['hg', 'clone', '--rev', 'tip', self.repo_url, self.repo_path],
-                    check=True,
-                    capture_output=True,
-                    text=True,
+    def test_specific_tag(self):
+        """Checkout a specific tag."""
+        with TemporaryDirectory(suffix='.hg_checkout') as tmp:
+            dest = os.path.join(tmp, 'repo')
+            client = HgClient(dest)
+            url = to_file_url(os.path.join(self.temp_dir.name, 'hgrepo'))
+
+            result = client.checkout(url, version='5.8')
+            self.assertTrue(result)
+            self.assertTrue(HgClient.is_repository(dest))
+
+    def test_specific_hash(self):
+        """Checkout a specific changeset hash."""
+        with TemporaryDirectory(suffix='.hg_checkout') as tmp:
+            dest = os.path.join(tmp, 'repo')
+            client = HgClient(dest)
+            url = to_file_url(os.path.join(self.temp_dir.name, 'hgrepo'))
+
+            result = client.checkout(url, version='27ff6a32cacf')
+            self.assertTrue(result)
+            self.assertTrue(HgClient.is_repository(dest))
+
+    def test_nonempty_dir(self):
+        """Checkout into a non-empty directory should raise RuntimeError."""
+        with TemporaryDirectory(suffix='.hg_checkout') as tmp:
+            dest = os.path.join(tmp, 'repo')
+            os.makedirs(dest)
+            with open(os.path.join(dest, 'blocker.txt'), 'w', encoding='utf-8') as f:
+                f.write('occupied')
+
+            client = HgClient(dest)
+            url = to_file_url(os.path.join(self.temp_dir.name, 'hgrepo'))
+
+            with self.assertRaises(RuntimeError):
+                client.checkout(url)
+
+    def test_invalid_version(self):
+        """Checkout with a non-existent revision should return False."""
+        with TemporaryDirectory(suffix='.hg_checkout') as tmp:
+            dest = os.path.join(tmp, 'repo')
+            client = HgClient(dest)
+            url = to_file_url(os.path.join(self.temp_dir.name, 'hgrepo'))
+
+            result = client.checkout(url, version='nonexistent-rev-xyz')
+            self.assertFalse(result)
+
+    def test_invalid_url(self):
+        """Checkout from a non-existent local repository should return False."""
+        with TemporaryDirectory(suffix='.hg_checkout') as tmp:
+            dest = os.path.join(tmp, 'repo')
+            client = HgClient(dest)
+            url = to_file_url(os.path.join(self.temp_dir.name, 'does-not-exist'))
+
+            result = client.checkout(url)
+            self.assertFalse(result)
+
+
+class TestHgExportRepository(StagedReposFile2):
+    """Test HgClient.export_repository using the staged hg repository."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls._export_dir = TemporaryDirectory(suffix='.hg_export')
+        cls._export_path = os.path.join(cls._export_dir.name, 'repo')
+        client = HgClient(cls._export_path)
+        url = to_file_url(os.path.join(cls.temp_dir.name, 'hgrepo'))
+        assert client.checkout(url), 'Failed to clone staged hg repo'
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._export_dir.cleanup()
+        super().tearDownClass()
+
+    def test_creates_tarball(self):
+        """export_repository should create a .tar.gz archive."""
+        with TemporaryDirectory(suffix='.hg_export') as tmp:
+            basepath = os.path.join(tmp, 'export')
+            client = HgClient(self._export_path)
+
+            result = client.export_repository('5.8', basepath)
+            self.assertTrue(result)
+            self.assertTrue(os.path.isfile(basepath + '.tar.gz'))
+
+            with tarfile.open(basepath + '.tar.gz', 'r:gz') as tar:
+                names = tar.getnames()
+                self.assertTrue(len(names) > 0)
+
+    def test_contains_license(self):
+        """Exported archive should contain LICENSE."""
+        with TemporaryDirectory(suffix='.hg_export') as tmp:
+            basepath = os.path.join(tmp, 'export')
+            client = HgClient(self._export_path)
+
+            result = client.export_repository('5.8', basepath)
+            self.assertTrue(result)
+
+            with tarfile.open(basepath + '.tar.gz', 'r:gz') as tar:
+                names = tar.getnames()
+                self.assertTrue(
+                    any('LICENSE' in n for n in names),
+                    f'LICENSE not found in archive: {names}',
                 )
-            except subprocess.CalledProcessError as e:
-                self.fail(f'Failed to clone repository: {e.stderr}')
 
-    def test_export_repository_specific_revision(self):
-        """Test exporting a specific revision"""
-        result = self.hg_client.export_repository('1', self.export_base_path)
-        self.assertTrue(result, "Export should succeed for revision '1'")
+    def test_invalid_version(self):
+        """export_repository with a bad revision should return False."""
+        with TemporaryDirectory(suffix='.hg_export') as tmp:
+            basepath = os.path.join(tmp, 'export')
+            client = HgClient(self._export_path)
 
-        # Verify files were created correctly
-        tar_gz_path = self.export_base_path + '.tar.gz'
-        self.assertTrue(os.path.exists(tar_gz_path))
-
-    def test_export_repository_invalid_revision(self):
-        """Test exporting with an invalid revision"""
-        invalid_revision = 'nonexistent123456789'
-
-        result = self.hg_client.export_repository(
-            invalid_revision, self.export_base_path
-        )
-        self.assertFalse(result, 'Export should fail for invalid revision')
-
-        tar_gz_path = self.export_base_path + '.tar.gz'
-        tar_path = self.export_base_path + '.tar'
-        self.assertFalse(os.path.exists(tar_gz_path))
-        self.assertFalse(os.path.exists(tar_path))
+            result = client.export_repository('nonexistent-rev-xyz', basepath)
+            self.assertFalse(result)
 
 
 if __name__ == '__main__':

--- a/test/test_svn.py
+++ b/test/test_svn.py
@@ -1,0 +1,89 @@
+"""Integration tests for SvnClient class."""
+
+import os
+import subprocess
+import tempfile
+import unittest
+from shutil import which
+
+from vcs2l.clients.svn import SvnClient
+from vcs2l.util import rmtree
+
+svn = which('svn')
+
+
+@unittest.skipIf(not svn, '`svn` was not found')
+class TestCheckout(unittest.TestCase):
+    """Test cases for SvnClient checkout method."""
+
+    def setUp(self):
+        # Create a temporary directory for testing
+        self.test_dir = tempfile.mkdtemp(prefix='svn_test_')
+        self.repo_url = 'https://svn.apache.org/repos/asf/abdera/abdera2/'
+        self.client = SvnClient(self.test_dir)
+
+    def tearDown(self):
+        if os.path.exists(self.test_dir):
+            rmtree(self.test_dir)
+
+    def test_checkout_version(self):
+        """Test checkout repository with specific revision"""
+        version = '1928014'  # Specific revision number
+
+        result = self.client.checkout(self.repo_url, version=version)
+
+        self.assertTrue(result, 'Checkout with specific version should succeed')
+
+        # Verify that .svn directory exists
+        svn_dir = os.path.join(self.test_dir, '.svn')
+        self.assertTrue(
+            os.path.exists(svn_dir), '.svn directory should exist after checkout'
+        )
+
+        # Verify the checked out revision (using svn info)
+        try:
+            result = subprocess.run(
+                ['svn', 'info', '--show-item', 'revision'],
+                check=True,
+                cwd=self.test_dir,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            if result.returncode == 0:
+                actual_revision = result.stdout.strip()
+                self.assertEqual(
+                    actual_revision,
+                    version,
+                    f'Checked out revision should be {version}, got {actual_revision}',
+                )
+        except (
+            subprocess.TimeoutExpired,
+            subprocess.SubprocessError,
+            FileNotFoundError,
+        ):
+            self.fail('Failed to run svn info to verify revision')
+
+    def test_invalid_version(self):
+        """Test that checkout fails with invalid revision number"""
+        invalid_version = '999999999'
+
+        result = self.client.checkout(self.repo_url, version=invalid_version)
+
+        self.assertFalse(result, 'Checkout with invalid revision should fail')
+
+    def test_existing_non_empty_dir_should_fail(self):
+        """Test that checkout fails if target directory is not empty"""
+        # Create a file in the test directory first
+        test_file = os.path.join(self.test_dir, 'existing_file.txt')
+        with open(test_file, 'w', encoding='utf-8') as f:
+            f.write('This file already exists')
+
+        with self.assertRaises(RuntimeError) as context:
+            self.client.checkout(self.repo_url)
+
+        self.assertIn('Target path exists and is not empty', str(context.exception))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_svn.py
+++ b/test/test_svn.py
@@ -88,7 +88,7 @@ class TestCheckout(unittest.TestCase):
 
 @unittest.skipIf(not svn, '`svn` was not found')
 class TestSvnExportRepository(unittest.TestCase):
-    """Integration tests for SvnClient _export_repository functionality."""
+    """Integration tests for SvnClient export_repository functionality."""
 
     def setUp(self):
         self.test_dir = tempfile.mkdtemp()
@@ -110,7 +110,7 @@ class TestSvnExportRepository(unittest.TestCase):
         try:
             os.chdir(self.repo_path)
 
-            result = client._export_repository('1928014', self.export_path)
+            result = client.export_repository('1928014', self.export_path)
             self.assertTrue(result, 'Export should return True on success')
 
             # Verify tar.gz file was created
@@ -136,7 +136,7 @@ class TestSvnExportRepository(unittest.TestCase):
         try:
             os.chdir(self.repo_path)
 
-            result = client._export_repository('999999999', self.export_path)
+            result = client.export_repository('999999999', self.export_path)
             self.assertFalse(result, 'Export should return False for invalid version')
 
             archive_path = self.export_path + '.tar.gz'

--- a/test/test_svn.py
+++ b/test/test_svn.py
@@ -1,151 +1,132 @@
-"""Integration tests for SvnClient class."""
+"""Tests for SvnClient."""
 
 import os
-import subprocess
 import tarfile
-import tempfile
 import unittest
-from shutil import which
+from tempfile import TemporaryDirectory
 
 from vcs2l.clients.svn import SvnClient
-from vcs2l.util import rmtree
 
-svn = which('svn')
+from . import StagedReposFile2, to_file_url
 
 
-@unittest.skipIf(not svn, '`svn` was not found')
-class TestCheckout(unittest.TestCase):
-    """Test cases for SvnClient checkout method."""
+class TestSvnCheckout(StagedReposFile2):
+    """Test SvnClient.checkout using the staged svn repository."""
 
-    def setUp(self):
-        # Create a temporary directory for testing
-        self.test_dir = tempfile.mkdtemp(prefix='svn_test_')
-        self.repo_url = 'https://svn.apache.org/repos/asf/abdera/abdera2/'
-        self.client = SvnClient(self.test_dir)
+    def test_default_branch(self):
+        """Checkout without a version gets the latest revision."""
+        with TemporaryDirectory(suffix='.svn_checkout') as tmp:
+            dest = os.path.join(tmp, 'repo')
+            client = SvnClient(dest)
+            url = to_file_url(os.path.join(self.temp_dir.name, 'svnrepo'))
 
-    def tearDown(self):
-        if os.path.exists(self.test_dir):
-            rmtree(self.test_dir)
+            result = client.checkout(url)
+            self.assertTrue(result)
+            self.assertTrue(os.path.isdir(os.path.join(dest, '.svn')))
 
-    def test_checkout_version(self):
-        """Test checkout repository with specific revision"""
-        version = '1928014'  # Specific revision number
+    def test_specific_hash(self):
+        """Checkout at revision 1."""
+        with TemporaryDirectory(suffix='.svn_checkout') as tmp:
+            dest = os.path.join(tmp, 'repo')
+            client = SvnClient(dest)
+            url = to_file_url(os.path.join(self.temp_dir.name, 'svnrepo'))
 
-        result = self.client.checkout(self.repo_url, version=version)
+            result = client.checkout(url, version='1')
+            self.assertTrue(result)
+            self.assertTrue(os.path.isdir(os.path.join(dest, '.svn')))
+            # LICENSE was committed at rev 1
+            self.assertTrue(os.path.isfile(os.path.join(dest, 'LICENSE')))
 
-        self.assertTrue(result, 'Checkout with specific version should succeed')
+    def test_nonempty_dir(self):
+        """Checkout into a non-empty directory should raise RuntimeError."""
+        with TemporaryDirectory(suffix='.svn_checkout') as tmp:
+            dest = os.path.join(tmp, 'repo')
+            os.makedirs(dest)
+            with open(os.path.join(dest, 'blocker.txt'), 'w', encoding='utf-8') as f:
+                f.write('occupied')
 
-        # Verify that .svn directory exists
-        svn_dir = os.path.join(self.test_dir, '.svn')
-        self.assertTrue(
-            os.path.exists(svn_dir), '.svn directory should exist after checkout'
-        )
+            client = SvnClient(dest)
+            url = to_file_url(os.path.join(self.temp_dir.name, 'svnrepo'))
 
-        # Verify the checked out revision (using svn info)
-        try:
-            result = subprocess.run(
-                ['svn', 'info', '--show-item', 'revision'],
-                check=True,
-                cwd=self.test_dir,
-                capture_output=True,
-                text=True,
-                timeout=30,
-            )
-            if result.returncode == 0:
-                actual_revision = result.stdout.strip()
-                self.assertEqual(
-                    actual_revision,
-                    version,
-                    f'Checked out revision should be {version}, got {actual_revision}',
-                )
-        except (
-            subprocess.TimeoutExpired,
-            subprocess.SubprocessError,
-            FileNotFoundError,
-        ):
-            self.fail('Failed to run svn info to verify revision')
+            with self.assertRaises(RuntimeError):
+                client.checkout(url)
 
     def test_invalid_version(self):
-        """Test that checkout fails with invalid revision number"""
-        invalid_version = '999999999'
+        """Checkout with a non-existent revision should return False."""
+        with TemporaryDirectory(suffix='.svn_checkout') as tmp:
+            dest = os.path.join(tmp, 'repo')
+            client = SvnClient(dest)
+            url = to_file_url(os.path.join(self.temp_dir.name, 'svnrepo'))
 
-        result = self.client.checkout(self.repo_url, version=invalid_version)
+            result = client.checkout(url, version='9999')
+            self.assertFalse(result)
 
-        self.assertFalse(result, 'Checkout with invalid revision should fail')
+    def test_invalid_url(self):
+        """Checkout from a non-existent local repository should return False."""
+        with TemporaryDirectory(suffix='.svn_checkout') as tmp:
+            dest = os.path.join(tmp, 'repo')
+            client = SvnClient(dest)
+            url = to_file_url(os.path.join(self.temp_dir.name, 'does-not-exist'))
 
-    def test_existing_non_empty_dir_should_fail(self):
-        """Test that checkout fails if target directory is not empty"""
-        # Create a file in the test directory first
-        test_file = os.path.join(self.test_dir, 'existing_file.txt')
-        with open(test_file, 'w', encoding='utf-8') as f:
-            f.write('This file already exists')
-
-        with self.assertRaises(RuntimeError) as context:
-            self.client.checkout(self.repo_url)
-
-        self.assertIn('Target path exists and is not empty', str(context.exception))
+            result = client.checkout(url)
+            self.assertFalse(result)
 
 
-@unittest.skipIf(not svn, '`svn` was not found')
-class TestSvnExportRepository(unittest.TestCase):
-    """Integration tests for SvnClient export_repository functionality."""
+class TestSvnExportRepository(StagedReposFile2):
+    """Test SvnClient.export_repository using the staged svn repository."""
 
-    def setUp(self):
-        self.test_dir = tempfile.mkdtemp()
-        self.repo_url = 'https://svn.apache.org/repos/asf/abdera/abdera2/'
-        self.repo_path = os.path.join(self.test_dir, 'test_repo')
-        self.export_path = os.path.join(self.test_dir, 'export_test')
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls._export_dir = TemporaryDirectory(suffix='.svn_export')
+        cls._export_path = os.path.join(cls._export_dir.name, 'repo')
+        client = SvnClient(cls._export_path)
+        url = to_file_url(os.path.join(cls.temp_dir.name, 'svnrepo'))
+        assert client.checkout(url, version='1'), 'Failed to checkout staged svn repo'
 
-    def tearDown(self):
-        if os.path.exists(self.test_dir):
-            rmtree(self.test_dir)
+    @classmethod
+    def tearDownClass(cls):
+        cls._export_dir.cleanup()
+        super().tearDownClass()
 
-    def test_export_repository_with_version(self):
-        """Test export repository with specific version."""
-        client = SvnClient(self.repo_path)
-        client.checkout(self.repo_url)
+    def test_creates_tarball(self):
+        """export_repository should create a .tar.gz archive."""
+        with TemporaryDirectory(suffix='.svn_export') as tmp:
+            basepath = os.path.join(tmp, 'export')
+            client = SvnClient(self._export_path)
 
-        # Change to the repository directory for export
-        original_cwd = os.getcwd()
-        try:
-            os.chdir(self.repo_path)
+            result = client.export_repository('1', basepath)
+            self.assertTrue(result)
+            self.assertTrue(os.path.isfile(basepath + '.tar.gz'))
 
-            result = client.export_repository('1928014', self.export_path)
-            self.assertTrue(result, 'Export should return True on success')
+            with tarfile.open(basepath + '.tar.gz', 'r:gz') as tar:
+                names = tar.getnames()
+                self.assertTrue(len(names) > 0)
 
-            # Verify tar.gz file was created
-            archive_path = self.export_path + '.tar.gz'
-            self.assertTrue(
-                os.path.exists(archive_path), 'Archive file should be created'
-            )
+    def test_contains_license(self):
+        """Exported archive should contain LICENSE."""
+        with TemporaryDirectory(suffix='.svn_export') as tmp:
+            basepath = os.path.join(tmp, 'export')
+            client = SvnClient(self._export_path)
 
-            # Verify the archive is a valid tar.gz file
-            with tarfile.open(archive_path, 'r:gz') as tar:
-                members = tar.getnames()
-                self.assertGreater(len(members), 0, 'Archive should contain files')
+            result = client.export_repository('1', basepath)
+            self.assertTrue(result)
 
-        finally:
-            os.chdir(original_cwd)
+            with tarfile.open(basepath + '.tar.gz', 'r:gz') as tar:
+                names = tar.getnames()
+                self.assertTrue(
+                    any('LICENSE' in n for n in names),
+                    f'LICENSE not found in archive: {names}',
+                )
 
-    def test_export_repository_invalid_version(self):
-        """Test export repository with invalid version returns False."""
-        client = SvnClient(self.repo_path)
-        client.checkout(self.repo_url)
+    def test_invalid_version(self):
+        """export_repository with a bad revision should return False."""
+        with TemporaryDirectory(suffix='.svn_export') as tmp:
+            basepath = os.path.join(tmp, 'export')
+            client = SvnClient(self._export_path)
 
-        original_cwd = os.getcwd()
-        try:
-            os.chdir(self.repo_path)
-
-            result = client.export_repository('999999999', self.export_path)
-            self.assertFalse(result, 'Export should return False for invalid version')
-
-            archive_path = self.export_path + '.tar.gz'
-            self.assertFalse(
-                os.path.exists(archive_path), 'Archive should not be created on failure'
-            )
-
-        finally:
-            os.chdir(original_cwd)
+            result = client.export_repository('9999', basepath)
+            self.assertFalse(result)
 
 
 if __name__ == '__main__':

--- a/test/validate2.txt
+++ b/test/validate2.txt
@@ -2,7 +2,7 @@
 === hg/branch (hg) ===
 Found hg repository 'file:///vcstmp/hgrepo' with changeset 'stable'
 === hg/hash (hg) ===
-Found hg repository 'file:///vcstmp/hgrepo' with changeset '9bd654917508'
+Found hg repository 'file:///vcstmp/hgrepo' with changeset '27ff6a32cacf'
 === hg/tag (hg) ===
 Found hg repository 'file:///vcstmp/hgrepo' with changeset '5.8'
 === svn/rev (svn) ===

--- a/vcs2l/clients/__init__.py
+++ b/vcs2l/clients/__init__.py
@@ -47,3 +47,24 @@ if len(_client_types) != len(set(_client_types)):
     raise RuntimeError(
         'Multiple vcs clients share the same type: ' + ', '.join(sorted(_client_types))
     )
+
+
+def get_vcs_client(vcs_type, uri):
+    """
+    Get a VCS client instance for the specified type and URI.
+
+    Args:
+        vcs_type: The type of VCS (e.g., 'git', 'svn', 'hg', etc.)
+        uri: The repository URI/path
+
+    Returns:
+        An instance of the appropriate VCS client
+
+    Raises:
+        ValueError: If no client supports the specified type
+    """
+    for client_class in vcs2l_clients:
+        if client_class.type == vcs_type:
+            return client_class(uri)
+
+    raise ValueError(f'No VCS client found for type: {vcs_type}')

--- a/vcs2l/clients/__init__.py
+++ b/vcs2l/clients/__init__.py
@@ -1,42 +1,42 @@
 vcs2l_clients = []
 
 try:
-    from .bzr import BzrClient
+    from vcs2l.clients.bzr import BzrClient
 
     vcs2l_clients.append(BzrClient)
 except ImportError:
     pass
 
 try:
-    from .git import GitClient
+    from vcs2l.clients.git import GitClient
 
     vcs2l_clients.append(GitClient)
 except ImportError:
     pass
 
 try:
-    from .hg import HgClient
+    from vcs2l.clients.hg import HgClient
 
     vcs2l_clients.append(HgClient)
 except ImportError:
     pass
 
 try:
-    from .svn import SvnClient
+    from vcs2l.clients.svn import SvnClient
 
     vcs2l_clients.append(SvnClient)
 except ImportError:
     pass
 
 try:
-    from .tar import TarClient
+    from vcs2l.clients.tar import TarClient
 
     vcs2l_clients.append(TarClient)
 except ImportError:
     pass
 
 try:
-    from .zip import ZipClient
+    from vcs2l.clients.zip import ZipClient
 
     vcs2l_clients.append(ZipClient)
 except ImportError:

--- a/vcs2l/clients/bzr.py
+++ b/vcs2l/clients/bzr.py
@@ -194,6 +194,21 @@ class BzrClient(VcsClientBase):
         result['output'] = branch
         return result
 
+    def _export_repository(self, version, basepath):
+        """Export the bzr repository at a given version to a tar.gz file."""
+        self._check_executable()
+
+        # Construct the bzr export command
+        cmd = [BzrClient._executable, 'export', '--format=tgz', basepath + '.tar.gz']
+
+        if version:
+            cmd.append('--revision')
+            cmd.append(version)
+
+        result = self._run_command(cmd)
+
+        return result['returncode'] == 0
+
     def checkout(self, url, version=None, verbose=False, shallow=False, timeout=None):
         """Creates a local Bazaar branch from a remote repository."""
         if url is None or url.strip() == '':

--- a/vcs2l/clients/bzr.py
+++ b/vcs2l/clients/bzr.py
@@ -194,6 +194,51 @@ class BzrClient(VcsClientBase):
         result['output'] = branch
         return result
 
+    def checkout(self, url, version=None, verbose=False, shallow=False, timeout=None):
+        """Creates a local Bazaar branch from a remote repository."""
+        if url is None or url.strip() == '':
+            raise ValueError('Invalid empty url: "%s"' % url)
+
+        # Check if directory exists and is not empty
+        if os.path.exists(self.path) and os.listdir(self.path):
+            raise RuntimeError('Target path exists and is not empty: %s' % self.path)
+
+        # Create parent directory if it doesn't exist, but not the target directory itself
+        # This is because 'bzr branch' will create the target directory.
+        parent_dir = os.path.dirname(self.path)
+        if parent_dir and not os.path.exists(parent_dir):
+            result = self._create_path()
+            if result and result.get('returncode'):
+                return False
+
+        self._check_executable()
+
+        # Build the branch command
+        cmd = ['bzr', 'branch']
+
+        if verbose:
+            cmd.append('--verbose')
+
+        if version:
+            cmd.extend(['--revision', str(version)])
+
+        # let bzr create the target directory
+        cmd.extend([url, self.path])
+
+        # Run the command with proper timeout handling
+        try:
+            result = self._run_command(cmd)
+        except Exception as e:
+            print('Branch command failed with exception: %s' % str(e))
+            return False
+
+        if result['returncode'] != 0:
+            error_msg = result.get('output', 'Unknown error')
+            print('Branch failed: %s' % error_msg)
+            return False
+
+        return True
+
     def _check_executable(self):
         assert BzrClient._executable is not None, "Could not find 'bzr' executable"
 

--- a/vcs2l/clients/bzr.py
+++ b/vcs2l/clients/bzr.py
@@ -194,7 +194,7 @@ class BzrClient(VcsClientBase):
         result['output'] = branch
         return result
 
-    def _export_repository(self, version, basepath):
+    def export_repository(self, version, basepath):
         """Export the bzr repository at a given version to a tar.gz file."""
         self._check_executable()
 

--- a/vcs2l/clients/bzr.py
+++ b/vcs2l/clients/bzr.py
@@ -241,11 +241,7 @@ class BzrClient(VcsClientBase):
         cmd.extend([url, self.path])
 
         # Run the command with proper timeout handling
-        try:
-            result = self._run_command(cmd)
-        except Exception as e:
-            print('Branch command failed with exception: %s' % str(e))
-            return False
+        result = self._run_command(cmd, timeout=timeout)
 
         if result['returncode'] != 0:
             error_msg = result.get('output', 'Unknown error')

--- a/vcs2l/clients/bzr.py
+++ b/vcs2l/clients/bzr.py
@@ -216,7 +216,7 @@ class BzrClient(VcsClientBase):
 
         # Check if directory exists and is not empty
         if os.path.exists(self.path) and os.listdir(self.path):
-            raise RuntimeError('Target path exists and is not empty: %s' % self.path)
+            raise RuntimeError(f'Target path exists and is not empty: {self.path}')
 
         # Create parent directory if it doesn't exist, but not the target directory itself
         # This is because 'bzr branch' will create the target directory.

--- a/vcs2l/clients/git.py
+++ b/vcs2l/clients/git.py
@@ -800,6 +800,76 @@ class GitClient(VcsClientBase):
         if GitClient._config_color_is_auto:
             cmd[1:1] = '-c', 'color.ui=always'
 
+    def checkout(self, url, version=None, verbose=False, shallow=False, timeout=None):
+        """Clone a git repository to the specified path and checkout a specific version."""
+        if url is None or url.strip() == '':
+            raise ValueError('Invalid empty url: "%s"' % url)
+
+        self._check_executable()
+
+        if os.path.exists(self.path):
+            if os.path.isdir(self.path):
+                # Check if directory is empty
+                if os.listdir(self.path):
+                    return False
+            else:
+                return False
+        else:
+            # Create parent directories
+            try:
+                os.makedirs(self.path, exist_ok=True)
+            except OSError:
+                return False
+
+        try:
+            cmd_clone = [GitClient._executable, 'clone']
+
+            if shallow:
+                cmd_clone.extend(['--depth', '1'])
+                if self.get_git_version() >= [1, 7, 10]:
+                    cmd_clone.append('--no-single-branch')
+
+            if version is None:
+                cmd_clone.append('--recursive')
+
+            cmd_clone.extend([url, '.'])
+
+            result_clone = self._run_command(cmd_clone)
+            if result_clone['returncode']:
+                return False
+
+            # Checkout specific version if provided
+            if version:
+                cmd_checkout = [GitClient._executable, 'checkout', version]
+                result_checkout = self._run_command(cmd_checkout)
+
+                if result_checkout['returncode']:
+                    # Try fetching all refs first
+                    cmd_fetch = [GitClient._executable, 'fetch', '--all', '--tags']
+                    result_fetch = self._run_command(cmd_fetch)
+                    if result_fetch['returncode'] == 0:
+                        result_checkout = self._run_command(cmd_checkout)
+
+                    if result_checkout['returncode']:
+                        return False
+
+                # Update submodules after version checkout
+                cmd_submodules = [
+                    GitClient._executable,
+                    'submodule',
+                    'update',
+                    '--init',
+                    '--recursive',
+                ]
+                result_submodules = self._run_command(cmd_submodules)
+                if result_submodules['returncode']:
+                    return False
+
+            return True
+
+        except Exception:
+            return False
+
     def _check_executable(self):
         assert GitClient._executable is not None, "Could not find 'git' executable"
 

--- a/vcs2l/clients/git.py
+++ b/vcs2l/clients/git.py
@@ -829,60 +829,56 @@ class GitClient(VcsClientBase):
         if os.path.exists(self.path) and os.listdir(self.path):
             raise RuntimeError(f'Target path exists and is not empty: {self.path}')
 
-            # Create parent directories
-            try:
-                os.makedirs(self.path, exist_ok=True)
-            except OSError:
-                return False
-
+        # Create parent directories
         try:
-            cmd_clone = [GitClient._executable, 'clone']
+            os.makedirs(self.path, exist_ok=True)
+        except OSError:
+            return False
 
-            if shallow:
-                cmd_clone.extend(['--depth', '1'])
-                if self.get_git_version() >= [1, 7, 10]:
-                    cmd_clone.append('--no-single-branch')
+        cmd_clone = [GitClient._executable, 'clone']
 
-            if version is None:
-                cmd_clone.append('--recursive')
+        if shallow:
+            cmd_clone.extend(['--depth', '1'])
+            if self.get_git_version() >= [1, 7, 10]:
+                cmd_clone.append('--no-single-branch')
 
-            cmd_clone.extend([url, '.'])
+        if version is None:
+            cmd_clone.append('--recursive')
 
-            result_clone = self._run_command(cmd_clone)
-            if result_clone['returncode']:
-                return False
+        cmd_clone.extend([url, '.'])
 
-            # Checkout specific version if provided
-            if version:
-                cmd_checkout = [GitClient._executable, 'checkout', version]
-                result_checkout = self._run_command(cmd_checkout)
+        result_clone = self._run_command(cmd_clone, timeout=timeout)
+        if result_clone['returncode']:
+            return False
+
+        # Checkout specific version if provided
+        if version:
+            cmd_checkout = [GitClient._executable, 'checkout', version]
+            result_checkout = self._run_command(cmd_checkout, timeout=timeout)
+
+            if result_checkout['returncode']:
+                # Try fetching all refs first
+                cmd_fetch = [GitClient._executable, 'fetch', '--all', '--tags']
+                result_fetch = self._run_command(cmd_fetch, timeout=timeout)
+                if result_fetch['returncode'] == 0:
+                    result_checkout = self._run_command(cmd_checkout, timeout=timeout)
 
                 if result_checkout['returncode']:
-                    # Try fetching all refs first
-                    cmd_fetch = [GitClient._executable, 'fetch', '--all', '--tags']
-                    result_fetch = self._run_command(cmd_fetch)
-                    if result_fetch['returncode'] == 0:
-                        result_checkout = self._run_command(cmd_checkout)
-
-                    if result_checkout['returncode']:
-                        return False
-
-                # Update submodules after version checkout
-                cmd_submodules = [
-                    GitClient._executable,
-                    'submodule',
-                    'update',
-                    '--init',
-                    '--recursive',
-                ]
-                result_submodules = self._run_command(cmd_submodules)
-                if result_submodules['returncode']:
                     return False
 
-            return True
+            # Update submodules after version checkout
+            cmd_submodules = [
+                GitClient._executable,
+                'submodule',
+                'update',
+                '--init',
+                '--recursive',
+            ]
+            result_submodules = self._run_command(cmd_submodules, timeout=timeout)
+            if result_submodules['returncode']:
+                return False
 
-        except Exception:
-            return False
+        return True
 
     def _check_executable(self):
         assert GitClient._executable is not None, "Could not find 'git' executable"

--- a/vcs2l/clients/git.py
+++ b/vcs2l/clients/git.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import tempfile
 from itertools import takewhile
 from shutil import which
 
@@ -800,6 +801,47 @@ class GitClient(VcsClientBase):
         if GitClient._config_color_is_auto:
             cmd[1:1] = '-c', 'color.ui=always'
 
+    def export_repository(self, version, basepath):
+        """Export repository to a tar.gz file at the specified version."""
+        if not GitClient.is_repository(self.path):
+            return False
+
+        self._check_executable()
+        filepath = '{0}.tar.gz'.format(basepath)
+
+        # If current version matches export version and no local changes, export directly
+        current_sha = self._get_current_version()
+        export_sha = self._get_version_sha(version) if version else current_sha
+        if current_sha == export_sha and self._has_no_local_changes():
+            cmd = [
+                GitClient._executable,
+                'archive',
+                '--format=tar.gz',
+                '--output={}'.format(filepath),
+                version or 'HEAD',
+            ]
+            result = self._run_command(cmd)
+            if result['returncode'] == 0:
+                return filepath
+
+        # Otherwise use temp directory approach
+        tmpd_path = tempfile.mkdtemp()
+        try:
+            tmpgit = GitClient(tmpd_path)
+            if tmpgit.checkout(self.path, version=version, shallow=False):
+                cmd = [
+                    GitClient._executable,
+                    'archive',
+                    '--format=tar.gz',
+                    '--output={}'.format(filepath),
+                    version or 'HEAD',
+                ]
+                result = tmpgit._run_command(cmd)
+                return filepath if result['returncode'] == 0 else False
+            return False
+        finally:
+            rmtree(tmpd_path)
+
     def checkout(self, url, version=None, verbose=False, shallow=False, timeout=None):
         """Clone a git repository to the specified path and checkout a specific version."""
         if url is None or url.strip() == '':
@@ -884,6 +926,24 @@ class GitClient(VcsClientBase):
                 continue
             tuples.append((hash_, ref))
         return tuples
+
+    def _get_current_version(self):
+        """Get current HEAD SHA."""
+        cmd = [GitClient._executable, 'rev-parse', 'HEAD']
+        result = self._run_command(cmd)
+        return result['output'].strip() if result['returncode'] == 0 else None
+
+    def _get_version_sha(self, version):
+        """Get SHA for a given version."""
+        cmd = [GitClient._executable, 'rev-parse', version]
+        result = self._run_command(cmd)
+        return result['output'].strip() if result['returncode'] == 0 else None
+
+    def _has_no_local_changes(self):
+        """Check if there are no local changes."""
+        cmd = [GitClient._executable, 'diff', '--quiet']
+        result = self._run_command(cmd)
+        return result['returncode'] == 0
 
 
 if not GitClient._executable:

--- a/vcs2l/clients/git.py
+++ b/vcs2l/clients/git.py
@@ -825,14 +825,10 @@ class GitClient(VcsClientBase):
 
         self._check_executable()
 
-        if os.path.exists(self.path):
-            if os.path.isdir(self.path):
-                # Check if directory is empty
-                if os.listdir(self.path):
-                    return False
-            else:
-                return False
-        else:
+        # Check if directory exists and is not empty
+        if os.path.exists(self.path) and os.listdir(self.path):
+            raise RuntimeError(f'Target path exists and is not empty: {self.path}')
+
             # Create parent directories
             try:
                 os.makedirs(self.path, exist_ok=True)

--- a/vcs2l/clients/git.py
+++ b/vcs2l/clients/git.py
@@ -1,6 +1,5 @@
 import os
 import subprocess
-import tempfile
 from itertools import takewhile
 from shutil import which
 
@@ -807,40 +806,17 @@ class GitClient(VcsClientBase):
             return False
 
         self._check_executable()
-        filepath = '{0}.tar.gz'.format(basepath)
+        filepath = f'{basepath}.tar.gz'
 
-        # If current version matches export version and no local changes, export directly
-        current_sha = self._get_current_version()
-        export_sha = self._get_version_sha(version) if version else current_sha
-        if current_sha == export_sha and self._has_no_local_changes():
-            cmd = [
-                GitClient._executable,
-                'archive',
-                '--format=tar.gz',
-                '--output={}'.format(filepath),
-                version or 'HEAD',
-            ]
-            result = self._run_command(cmd)
-            if result['returncode'] == 0:
-                return filepath
-
-        # Otherwise use temp directory approach
-        tmpd_path = tempfile.mkdtemp()
-        try:
-            tmpgit = GitClient(tmpd_path)
-            if tmpgit.checkout(self.path, version=version, shallow=False):
-                cmd = [
-                    GitClient._executable,
-                    'archive',
-                    '--format=tar.gz',
-                    '--output={}'.format(filepath),
-                    version or 'HEAD',
-                ]
-                result = tmpgit._run_command(cmd)
-                return filepath if result['returncode'] == 0 else False
-            return False
-        finally:
-            rmtree(tmpd_path)
+        cmd = [
+            GitClient._executable,
+            'archive',
+            '--format=tar.gz',
+            f'--output={filepath}',
+            version or 'HEAD',
+        ]
+        result = self._run_command(cmd)
+        return filepath if result['returncode'] == 0 else False
 
     def checkout(self, url, version=None, verbose=False, shallow=False, timeout=None):
         """Clone a git repository to the specified path and checkout a specific version."""

--- a/vcs2l/clients/hg.py
+++ b/vcs2l/clients/hg.py
@@ -340,7 +340,7 @@ class HgClient(VcsClientBase):
         if HgClient._config_color:
             cmd[1:1] = '--color', 'always'
 
-    def _export_repository(self, version, basepath):
+    def export_repository(self, version, basepath):
         """Export the hg repository at a given version to a tar.gz file."""
         self._check_executable()
 

--- a/vcs2l/clients/hg.py
+++ b/vcs2l/clients/hg.py
@@ -389,34 +389,24 @@ class HgClient(VcsClientBase):
             except OSError:
                 return False
 
-        try:
-            # Clone repository
-            cmd_clone = [HgClient._executable, 'clone', url, self.path]
-            result_clone = self._run_command(cmd_clone)
+        # Clone repository
+        cmd_clone = [HgClient._executable, 'clone', url, self.path]
+        result_clone = self._run_command(cmd_clone, timeout=timeout)
 
-            if result_clone['returncode'] != 0:
-                print(
-                    "Could not clone repository '%s': %s"
-                    % (url, result_clone['output'])
-                )
+        if result_clone['returncode'] != 0:
+            print(f"Could not clone repository '{url}': {result_clone['output']}")
+            return False
+
+        # Checkout specific version if provided
+        if version and version.strip():
+            cmd_checkout = [HgClient._executable, 'update', version.strip()]
+            result_checkout = self._run_command(cmd_checkout, timeout=timeout)
+
+            if result_checkout['returncode'] != 0:
+                print(f"Could not checkout '{version}': {result_checkout['output']}")
                 return False
 
-            # Checkout specific version if provided
-            if version and version.strip():
-                cmd_checkout = [HgClient._executable, 'update', version.strip()]
-                result_checkout = self._run_command(cmd_checkout)
-
-                if result_checkout['returncode'] != 0:
-                    print(
-                        "Could not checkout '%s': %s"
-                        % (version, result_checkout['output'])
-                    )
-                    return False
-
-            return True
-
-        except Exception:
-            return False
+        return True
 
     def _check_executable(self):
         assert HgClient._executable is not None, "Could not find 'hg' executable"

--- a/vcs2l/clients/hg.py
+++ b/vcs2l/clients/hg.py
@@ -377,13 +377,9 @@ class HgClient(VcsClientBase):
 
         self._check_executable()
 
-        # Check if path exists and handle accordingly
-        if os.path.exists(self.path):
-            if os.path.isdir(self.path):
-                if os.listdir(self.path):
-                    return False
-            else:
-                return False
+        # Check if directory exists and is not empty
+        if os.path.exists(self.path) and os.listdir(self.path):
+            raise RuntimeError(f'Target path exists and is not empty: {self.path}')
 
         # Ensure parent directory exists
         parent_dir = os.path.dirname(self.path)

--- a/vcs2l/clients/svn.py
+++ b/vcs2l/clients/svn.py
@@ -261,7 +261,7 @@ class SvnClient(VcsClientBase):
 
         return {'cmd': cmd, 'cwd': self.path, 'output': output, 'returncode': None}
 
-    def _export_repository(self, version, basepath):
+    def export_repository(self, version, basepath):
         """Export the svn repository at a given version to a tar.gz file."""
         self._check_executable()
 

--- a/vcs2l/clients/svn.py
+++ b/vcs2l/clients/svn.py
@@ -349,7 +349,7 @@ class SvnClient(VcsClientBase):
         # Add URL and target directory
         cmd.extend([url, '.'])
 
-        result = self._run_command(cmd)
+        result = self._run_command(cmd, timeout=timeout)
 
         if result['returncode']:
             if result['output']:

--- a/vcs2l/clients/svn.py
+++ b/vcs2l/clients/svn.py
@@ -331,7 +331,7 @@ class SvnClient(VcsClientBase):
 
         # Check if directory exists and is not empty
         if os.path.exists(self.path) and os.listdir(self.path):
-            raise RuntimeError('Target path exists and is not empty: %s' % self.path)
+            raise RuntimeError(f'Target path exists and is not empty: {self.path}')
 
         # Create the directory if it doesn't exist
         not_exist = self._create_path()

--- a/vcs2l/clients/tar.py
+++ b/vcs2l/clients/tar.py
@@ -4,6 +4,7 @@ from io import BytesIO
 from urllib.error import URLError
 
 from vcs2l.clients.vcs_base import VcsClientBase, load_url, test_url
+from vcs2l.errors import Vcs2lError
 from vcs2l.util import rmtree
 
 
@@ -113,3 +114,5 @@ class TarClient(VcsClientBase):
             'output': "Tarball url '%s' exists" % command.url,
             'returncode': None,
         }
+    def checkout(self, url, version=None, verbose=False, shallow=False, timeout=None):
+        raise Vcs2lError('checkout not implemented for extracted tars.')

--- a/vcs2l/clients/tar.py
+++ b/vcs2l/clients/tar.py
@@ -115,5 +115,8 @@ class TarClient(VcsClientBase):
             'returncode': None,
         }
 
+    def export_repository(self, version, basepath):
+        raise Vcs2lError('export repository not implemented for extracted tars')
+
     def checkout(self, url, version=None, verbose=False, shallow=False, timeout=None):
         raise Vcs2lError('checkout not implemented for extracted tars.')

--- a/vcs2l/clients/tar.py
+++ b/vcs2l/clients/tar.py
@@ -114,5 +114,6 @@ class TarClient(VcsClientBase):
             'output': "Tarball url '%s' exists" % command.url,
             'returncode': None,
         }
+
     def checkout(self, url, version=None, verbose=False, shallow=False, timeout=None):
         raise Vcs2lError('checkout not implemented for extracted tars.')

--- a/vcs2l/clients/vcs_base.py
+++ b/vcs2l/clients/vcs_base.py
@@ -69,6 +69,10 @@ class VcsClientBase(object):
                 }
         return None
 
+    def get_path(self):
+        """Get the local path of the repository."""
+        return self.path
+
     def export_repository(self, version, basepath):
         """Export the repository at the given version to the given basepath.
 

--- a/vcs2l/clients/vcs_base.py
+++ b/vcs2l/clients/vcs_base.py
@@ -69,6 +69,20 @@ class VcsClientBase(object):
                 }
         return None
 
+    def export_repository(self, version, basepath):
+        """Export the repository at the given version to the given basepath.
+
+        Args:
+            version: the version to export
+            basepath: the path to export to
+        Returns:
+            A dict with keys 'cmd', 'cwd', 'output', and 'returncode'.
+        """
+        raise NotImplementedError(
+            'Base class export_repository method must be overridden for client type %s '
+            % self.__class__.type
+        )
+
     def checkout(self, url, version=None, verbose=False, shallow=False, timeout=None):
         """Checkout the repository from the given URL.
 

--- a/vcs2l/clients/vcs_base.py
+++ b/vcs2l/clients/vcs_base.py
@@ -69,6 +69,23 @@ class VcsClientBase(object):
                 }
         return None
 
+    def checkout(self, url, version=None, verbose=False, shallow=False, timeout=None):
+        """Checkout the repository from the given URL.
+
+        Args:
+            url: the URL to checkout from
+            version: the version to checkout (branch, tag, or revision)
+            verbose: whether to run the command in verbose mode
+            shallow: whether to perform a shallow checkout (if supported)
+            timeout: timeout for network operations (if supported)
+        Returns:
+            True on success, False otherwise.
+        """
+        raise NotImplementedError(
+            'Base class checkout method must be overridden for client type %s '
+            % self._vcs_type_name
+        )
+
 
 def run_command(cmd, cwd, env=None):
     if not os.path.exists(cwd):

--- a/vcs2l/clients/vcs_base.py
+++ b/vcs2l/clients/vcs_base.py
@@ -6,6 +6,7 @@ import time
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
+from vcs2l.errors import Vcs2lError
 from vcs2l.executor import ansi
 
 
@@ -36,7 +37,7 @@ class VcsClientBase(object):
             'returncode': NotImplemented,
         }
 
-    def _run_command(self, cmd, env=None, retry=0):
+    def _run_command(self, cmd, env=None, retry=0, timeout=None):
         for i in range(retry + 1):
             if i > 0:
                 print(
@@ -45,7 +46,15 @@ class VcsClientBase(object):
                     + ansi('reset'),
                     file=sys.stderr,
                 )
-            result = run_command(cmd, os.path.abspath(self.path), env=env)
+            try:
+                result = run_command(
+                    cmd, os.path.abspath(self.path), env=env, timeout=timeout
+                )
+            except Exception as e:
+                raise Vcs2lError(
+                    f"Unexpected error while running command '{' '.join(cmd)}' "
+                    f'in {self.path}: {e}'
+                ) from e
             if not result['returncode']:
                 # return successful result
                 break
@@ -105,7 +114,7 @@ class VcsClientBase(object):
         )
 
 
-def run_command(cmd, cwd, env=None):
+def run_command(cmd, cwd, env=None, timeout=None):
     if not os.path.exists(cwd):
         cwd = None
     result = {'cmd': ' '.join(cmd), 'cwd': cwd}
@@ -113,7 +122,18 @@ def run_command(cmd, cwd, env=None):
         proc = subprocess.Popen(
             cmd, cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, env=env
         )
-        output, _ = proc.communicate()
+        try:
+            output, _ = proc.communicate(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            output, _ = proc.communicate()
+            partial_output = output.rstrip().decode('utf8')
+            message = f'Command timed out after {timeout} seconds'
+            if partial_output:
+                message += f': {partial_output}'
+            result['output'] = message
+            result['returncode'] = proc.returncode or 1
+            return result
         result['output'] = output.rstrip().decode('utf8')
         result['returncode'] = proc.returncode
     except subprocess.CalledProcessError as e:

--- a/vcs2l/clients/zip.py
+++ b/vcs2l/clients/zip.py
@@ -130,5 +130,8 @@ class ZipClient(VcsClientBase):
             'returncode': None,
         }
 
+    def export_repository(self, version, basepath):
+        raise Vcs2lError('export repository not implemented for extracted zips')
+
     def checkout(self, url, version=None, verbose=False, shallow=False, timeout=None):
         raise Vcs2lError('checkout not implemented for extracted zips.')

--- a/vcs2l/clients/zip.py
+++ b/vcs2l/clients/zip.py
@@ -4,6 +4,7 @@ from io import BytesIO
 from urllib.error import URLError
 
 from vcs2l.clients.vcs_base import VcsClientBase, load_url, test_url
+from vcs2l.errors import Vcs2lError
 from vcs2l.util import rmtree
 
 
@@ -128,3 +129,5 @@ class ZipClient(VcsClientBase):
             'output': "Zip url '%s' exists" % command.url,
             'returncode': None,
         }
+    def checkout(self, url, version=None, verbose=False, shallow=False, timeout=None):
+        raise Vcs2lError('checkout not implemented for extracted zips.')

--- a/vcs2l/clients/zip.py
+++ b/vcs2l/clients/zip.py
@@ -129,5 +129,6 @@ class ZipClient(VcsClientBase):
             'output': "Zip url '%s' exists" % command.url,
             'returncode': None,
         }
+
     def checkout(self, url, version=None, verbose=False, shallow=False, timeout=None):
         raise Vcs2lError('checkout not implemented for extracted zips.')


### PR DESCRIPTION
> [!NOTE]  
> Please refer [#751](https://github.com/ros-infrastructure/bloom/pull/751) for verifying integration with bloom.

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A |
| Primary OS tested on | Ubuntu|
| Is this a breaking change? | No |
| Does this PR contain [AI generated](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md) software? | No |

---

## Description of contribution in a few bullet points
* This ports over four main functions from vcstools, namely `export_repositories` , `checkout`, `get_vcs_client`, and `get_path` for all the VCS clients.

* This is because these are the four prominent methods used in bloom as seen here.
   * `checkout` [reference](https://github.com/ros-infrastructure/bloom/blob/master/bloom/commands/export_upstream.py#L119)
   * `export_repositories` [reference](https://github.com/ros-infrastructure/bloom/blob/master/bloom/commands/export_upstream.py#L127)
   * `get_vcs_client` [reference](https://github.com/ros-infrastructure/bloom/blob/master/bloom/commands/export_upstream.py#L62)
   * `get_path` [reference](https://github.com/ros-infrastructure/bloom/blob/6199b2a76f50f120a398c48c44b1e1ffd6c5f38f/bloom/commands/export_upstream.py#L131)
   
* In addition, the corresponding integration tests have been added to both of these functions across `svn`, `bzr`, `hg`, and `git` clients.

* Breezy has been added to the CI for testing on macOS and Ubuntu.

* The integration can be safely verified in [#751](https://github.com/ros-infrastructure/bloom/pull/751) at bloom. All the system and unit tests pass upon merge.

## Description of how this change was tested

* Ran `pytest` locally to ensure all the unit and linting tests pass:

   ```bash
   pytest -s -v test
   ```

Signed-off-by: Leander Stephen Desouza [leanderdsouza1234@gmail.com](mailto:leanderdsouza1234@gmail.com)