### PR TITLE
Removed warnings during building the package.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ with open(
 setup(
     name='vcs2l',
     version=__version__,
-    requires_python='>=3.5',
     install_requires=['PyYAML', 'setuptools'],
     extras_require={
         'test': [
@@ -39,7 +38,6 @@ setup(
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
         'Topic :: Software Development :: Version Control',
         'Topic :: Utilities',
@@ -48,7 +46,7 @@ setup(
     'on multiple repositories.',
     long_description=long_description,
     long_description_content_type='text/x-rst',
-    license='Apache License, Version 2.0',
+    license='Apache-2.0',
     data_files=[
         (
             'share/vcs2l-completion',


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A |
| Primary OS tested on | Ubuntu |
| Is this a breaking change? | No|
| Does this PR contain [AI generated](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md) software? | No |

---

## Description of contribution in a few bullet points
* Removed `requires_python` field due to the following build warning:

   ```bash
   /tmp/build-env-k4mdrul4/lib/python3.12/site-packages/setuptools/_distutils/dist.py:289: UserWarning: Unknown distribution option: 'requires_python'
  warnings.warn(msg)
  ```
* Removed Trove's classifiers for Apache License and used the [SPDX license expression](https://spdx.org/licenses/) instead due to the following build warning:

   ```bash
   /tmp/build-env-k4mdrul4/lib/python3.12/site-packages/setuptools/dist.py:759: SetuptoolsDeprecationWarning:    License classifiers are deprecated.
   !!
   
           ********************************************************************************
           Please consider removing the following classifiers in favor of a SPDX license expression:
   
           License :: OSI Approved :: Apache Software License
   
           See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
           ********************************************************************************
   
   !!
     self._finalize_license_expression()
   ```     

## Description of how this change was tested
* Tested the build process using `ros_release_python` and using the below command, and verified that there are no build warnings.

   ```bash
   python -m build
   ```

