### PR TITLE
Remove expected hints for shallow clone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ vcs2l.egg-info
 .pytest_cache
 __pycache__
 venv
+.ruff_cache
+test_workspace

--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -293,11 +293,21 @@ invocation.
                 ['--shallow', '--input', REPOS_FILE, '.'],
                 subfolder='import-shallow',
             )
+            # Normalize line endings for Windows and macOS compatibility
+            output = output.replace(b'\r\n', b'\n').replace(b'\r', b'\n')
+
             # the actual output contains absolute paths
             output = output.replace(
                 b'repository in ' + workdir.encode() + b'/', b'repository in ./'
             )
+            # delete lines in output that start with 'hint:'
+            lines = output.splitlines()
+            filtered_lines = [line for line in lines if not line.startswith(b'hint:')]
+            output = b'\n'.join(filtered_lines).strip() + b'\n'
+
             expected = get_expected_output('import_shallow')
+            expected = expected.replace(b'\r\n', b'\n').replace(b'\r', b'\n')
+
             # newer git versions don't append ... after the commit hash
             assert output == expected or output == expected.replace(b'... ', b' ')
 


### PR DESCRIPTION
## Basic Info
| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A |
| Primary OS tested on | Ubuntu|
| Is this a breaking change? | No |
| Does this PR contain [AI generated](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md) software? | No |

---

## Description of contribution in a few bullet points

* Adjusted the expected value of shallow clone to remove `hints:` before comparing with output.
This is seen in newer versions of git, where the following message is printed:

   ```bash
   hint: Using 'master' as the name f"
       +  b'or the initial branch. This default branch name\nhint: is subject to chan'
       +  b'ge. To configure the initial branch name to use in all\nhint: of your new'
       +  b' repositories, which will suppress this warning, call:\nhint:\nhint: \tgit '
       +  b'config --global init.defaultBranch
   ```
* This is motivated by #53, as the [disabling](https://github.com/ros-infrastructure/vcs2l/blob/main/.github/workflows/ci.yml#L59-L60) of the below messages is not possible when using a custom image with [ros-infrastructure/ci/.github/workflows/pytest.yaml@main](https://github.com/ros-infrastructure/vcs2l/pull/53/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR65).

   ```bash
   git config --global --add init.defaultBranch main
   git config --global --add advice.detachedHead true
   ```
   
* The hint messages are disabled only for the [`test_import_shallow`](https://github.com/ros-infrastructure/vcs2l/blob/main/test/test_commands.py#L287) test. This is because only this test fails under `ubuntu-latest`. If `windows-2025` or `macos-latest` images are used, all of them fail, as the hints are forced for all the git commands.

   Since the [`codecov`](https://github.com/ros-infrastructure/vcs2l/pull/53/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR68) action is only run on `ubuntu-latest`, disabling the `test_import_shallow` test is sufficient.

* Added the `test_workspace` to the `.gitignore` file to safely ignore the dummy folder during test runs.

## Description of how this change was tested

* Verified that the code passes all tests using `pytest -s -v test`

