### PR TITLE
Drop license classifier in favor of SPDX expression

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ setup(
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
         'Topic :: Software Development :: Version Control',
         'Topic :: Utilities',
@@ -48,7 +47,7 @@ setup(
     'on multiple repositories.',
     long_description=long_description,
     long_description_content_type='text/markdown',
-    license='Apache License, Version 2.0',
+    license='Apache-2.0',
     data_files=[
         (
             'share/vcs2l-completion',


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A |
| Primary OS tested on | Fedora |
| Is this a breaking change? | No |
| Does this PR contain [AI generated](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md) software? | No |

---

## Description of contribution in a few bullet points
Official Python packaging documentation new recommends using SPDX expressions instead of classifiers, and the latter is now deprecated.

Resolves:
```
SetuptoolsDeprecationWarning: License classifiers are deprecated.
!!

        ********************************************************************************
        Please consider removing the following classifiers in favor of a SPDX license expression:

        License :: OSI Approved :: Apache Software License

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
```

## Description of how this change was tested
When building the package with a sufficiently modern version of `setuptools`, the aforementioned deprecation warning is no longer printed when this change has been applied.