### PR TITLE
Disable Python warnings when capturing console output

### DIFF
--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -401,6 +401,7 @@ def run_command(command, args=None, subfolder=None):
     env.update(
         LANG='en_US.UTF-8',
         PYTHONPATH=repo_root + os.pathsep + env.get('PYTHONPATH', ''),
+        PYTHONWARNINGS='ignore',
     )
     cwd = TEST_WORKSPACE
     if subfolder:


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A |
| Primary OS tested on | Fedora |
| Is this a breaking change? | No |
| Does this PR contain [AI generated](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md) software? | No |

---

## Description of contribution in a few bullet points
Many of these tests capture and inspect console output from the executed commands. If Python warning messages are printed, these tests will fail.

For example, I see this message on RHEL 10:
```
RuntimeWarning: The default behavior of tarfile extraction has been changed to 
disallow common exploits (including CVE-2007-4559). By default, absolute/parent 
paths are disallowed and some mode bits are cleared.
See https://access.redhat.com/articles/7004769 for more details.
```

## Description of how this change was tested
Run tests on a system which emits warnings during normal execution.