### PR TITLE
Drop test dependencies on unused linters

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,11 +18,6 @@ setup(
     install_requires=['PyYAML', 'setuptools'],
     extras_require={
         'test': [
-            'flake8',
-            'flake8-docstrings',
-            'flake8-import-order',
-            'pycodestyle',
-            'pyflakes',
             'pytest',
         ]
     },


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A |
| Primary OS tested on | Fedora |
| Is this a breaking change? | No |
| Does this PR contain [AI generated](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md) software? | No |

---

## Description of contribution in a few bullet points
These linters don't appear to be used during testing.

## Description of how this change was tested
* Performed linting validation using `pre-commit run --all`
* Verified that the code passes all tests using `pytest -s -v test`
