### PR TITLE
Bump minimum Python version to 3.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ The biggest differences between the two are:
 - The file format of `vcstool export` uses the relative paths of the repositories as keys in YAML which avoids collisions by design.
 - `vcstool` has significantly fewer lines of code than `vcstools` including the command line tools built on top.
 
-## Python 3.5+ support
+## Python 3.6+ support
 
-The latest version supports Python 3.5 and newer.
-However, the CI is only run on Python 3.7 and newer, as there are no suitable GitHub Actions [runners](https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json/) available for Python 3.5 and 3.6.
+The latest version supports Python 3.6 and newer.
+However, the CI is only run on Python 3.7 and newer, as there are no suitable GitHub Actions [runners](https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json/) available for Python 3.6.
 
 ## How does it work?
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open(
 setup(
     name='vcs2l',
     version=__version__,
-    requires_python='>=3.5',
+    requires_python='>=3.6',
     install_requires=['PyYAML', 'setuptools'],
     extras_require={
         'test': [

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -3,4 +3,4 @@ No-Python2:
 Depends3: python3-setuptools, python3-yaml
 Conflicts3: python-vcstool, python3-vcstool
 Suite3: jammy noble bookworm trixie
-X-Python3-Version: >= 3.5
+X-Python3-Version: >= 3.6

--- a/vcs2l/errors.py
+++ b/vcs2l/errors.py
@@ -14,7 +14,7 @@ class Vcs2lError(Exception):
 class UnsupportedPythonVersionError(Vcs2lError):
     """Raised when the Python version is too old for vcs2l."""
 
-    def __init__(self, min_version: str = '3.5'):
+    def __init__(self, min_version: str = '3.6'):
         current_version = f'{sys.version_info.major}.{sys.version_info.minor}'
         message = (
             f'Unsupported Python version ({current_version}). '


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A |
| Primary OS tested on | Fedora |
| Is this a breaking change? | No |
| Does this PR contain [AI generated](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md) software? | No |

---

## Description of contribution in a few bullet points
This package uses f-strings, which are only available in Python 3.6 and newer. We don't really need support for Python 3.5 for any of our currently supported platforms, so rather than making the syntax compatible with Python 3.5, we should just tighten the support window.

## Description of how this change was tested
* Performed linting validation using `pre-commit run --all`
* Verified that the code passes all tests using `pytest -s -v test`
