### PR TITLE
Fix dependency for entry_points import

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The biggest differences between the two are:
 
 The latest version supports Python 3.6 and newer.
 However, the CI is only run on Python 3.7 and newer, as there are no suitable GitHub Actions [runners](https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json/) available for Python 3.6.
-Additionally, Debians can only be built for platforms with Python 3.8 and newer.
+Additionally, Debian packages can only be built for platforms with Python 3.8 and newer.
 
 ## How does it work?
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The biggest differences between the two are:
 
 The latest version supports Python 3.6 and newer.
 However, the CI is only run on Python 3.7 and newer, as there are no suitable GitHub Actions [runners](https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json/) available for Python 3.6.
+Additionally, Debians can only be built for platforms with Python 3.8 and newer.
 
 ## How does it work?
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,11 @@ setup(
     name='vcs2l',
     version=__version__,
     requires_python='>=3.5',
-    install_requires=['PyYAML', 'setuptools'],
+    install_requires=[
+        "importlib_metadata; python_version<'3.8' and python_version>='3.7'",
+        'PyYAML',
+        "setuptools; python_version<'3.7'",
+    ],
     extras_require={
         'test': [
             'flake8',

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,6 +1,6 @@
 [DEFAULT]
 No-Python2:
-Depends3: python3-setuptools, python3-yaml
+Depends3: python3-yaml
 Conflicts3: python-vcstool, python3-vcstool
 Suite3: jammy noble bookworm trixie
-X-Python3-Version: >= 3.5
+X-Python3-Version: >= 3.8


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A |
| Primary OS tested on | Fedora |
| Is this a breaking change? | No |
| Does this PR contain [AI generated](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md) software? | No |

---

## Description of contribution in a few bullet points
A previous commit changed vcs2l to use importlib{,_}resources instead of pkg_resources, but the dependency needs to be adjusted to align with the new requirements.

## Description of how this change was tested
* Performed linting validation using `pre-commit run --all`
* Verified that the code passes all tests using `pytest -s -v test`

Check dependencies using:
```shell
$ pip install git+https://github.com/ros-infrastructure/vcs2l.git@cottsay/entry-points-dep
```
* Python 3.6: requires `setuptools` and `PyYAML`
* Python 3.7: requires `importlib_metadata` and `PyYAML` (and two indirect dependencies of `importlib_metadata`)
* Python 3.8: requires only `PyYAML`