### PR TITLE
Ignore some nondeterministic line ordering in test_commands

### DIFF
--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -342,6 +342,9 @@ invocation.
                 subfolder='deletion',
             )
             expected = get_expected_output('delete')
+            # we don't care what order these messages appear in
+            output = b'\n'.join(sorted(output.split(b'\n')))
+            expected = b'\n'.join(sorted(output.split(b'\n')))
             self.assertEqual(output, expected)
 
             # check that repositories were actually deleted
@@ -365,6 +368,9 @@ invocation.
 
         output = run_command('validate', ['--hide-empty', '--input', REPOS_FILE])
         expected = get_expected_output('validate_hide')
+        # we don't care what order these messages appear in
+        output = b'\n'.join(sorted(output.split(b'\n')))
+        expected = b'\n'.join(sorted(output.split(b'\n')))
         self.assertEqual(output, expected)
 
         output = run_command('validate', ['--input', BAD_REPOS_FILE])


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A |
| Primary OS tested on | Fedora |
| Is this a breaking change? | No |
| Does this PR contain [AI generated](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md) software? | No |

---

## Description of contribution in a few bullet points
These tests inspect the console output from vcs2l itself, and the order in which the messages appears doesn't appear to be deterministic and can vary by platform, or in some cases, each invocation.

Modern Python versions will generally maintain the order in which values are added to a dictionary, which may be a preferable behavior here. Rather than sort the values when they're printed from vcs2l, we can just ignore the ordering in our checks. It may also be less performant to sort the values at runtime.

## Description of how this change was tested
* Performed linting validation using `pre-commit run --all`
* Verified that the code passes all tests using `pytest -s -v test`
* Also confirmed tests pass on older platforms like Ubuntu Xenial