### PR TITLE
Reduce unnecessary console output validation in test_commands

### DIFF
--- a/test/.gitconfig
+++ b/test/.gitconfig
@@ -6,3 +6,6 @@ abbrev = 7
 
 [init]
 defaultBranch = main
+
+[pull]
+rebase = false

--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -110,23 +110,6 @@ class TestCommands(unittest.TestCase):
             b'anch. Please specify which\nbranch you want to merge with. See',
             b'anch.\nPlease specify which branch you want to merge with.\nSee',
         )
-        # newer git versions warn on pull with default config
-        if GitClient.get_git_version() >= [2, 27, 0]:
-            pull_warning = b"""
-warning: Pulling without specifying how to reconcile divergent branches is
-discouraged. You can squelch this message by running one of the following
-commands sometime before your next pull:
-
-  git config pull.rebase false  # merge (the default strategy)
-  git config pull.rebase true   # rebase
-  git config pull.ff only       # fast-forward only
-
-You can replace "git config" with "git config --global" to set a default
-preference for all repositories. You can also pass --rebase, --no-rebase,
-or --ff-only on the command line to override the configured default per
-invocation.
-"""
-            output = output.replace(pull_warning, b'')
         self.assertEqual(output, expected)
 
     def test_pull_api(self):
@@ -176,23 +159,6 @@ invocation.
             'anch. Please specify which\nbranch you want to merge with. See',
             'anch.\nPlease specify which branch you want to merge with.\nSee',
         )
-        # newer git versions warn on pull with default config
-        if GitClient.get_git_version() >= [2, 27, 0]:
-            pull_warning = """
-warning: Pulling without specifying how to reconcile divergent branches is
-discouraged. You can squelch this message by running one of the following
-commands sometime before your next pull:
-
-  git config pull.rebase false  # merge (the default strategy)
-  git config pull.rebase true   # rebase
-  git config pull.ff only       # fast-forward only
-
-You can replace "git config" with "git config --global" to set a default
-preference for all repositories. You can also pass --rebase, --no-rebase,
-or --ff-only on the command line to override the configured default per
-invocation.
-"""
-            output = output.replace(pull_warning, '')
         # the output was retrieved through a different way here
         output = adapt_command_output(output.encode()).decode()
         if sys.platform == 'win32':
@@ -449,8 +415,6 @@ def adapt_command_output(output, cwd=None):
         b'Turn off this advice by setting config variable '
         b'advice.detachedHead to false',
     )
-    # replace GitHub SSH clone URL
-    output = output.replace(b'git@github.com:', b'https://github.com/')
     if sys.platform == 'win32':
         if cwd:
             # on Windows, git prints full path to repos


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A |
| Primary OS tested on | Fedora |
| Is this a breaking change? | No |
| Does this PR contain [AI generated](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md) software? | No |

---

## Description of contribution in a few bullet points
We don't really need the pull behavior hint to validate what's we're trying to do in these checks, so we can disable it in newer git clients to achieve the same behavior across the board.

Additionally, the addition of the static global `.gitconfig` file means that we don't need to worry about `insteadOf` mappings messing with our git URLs, so that workaround can be dropped.

I tried disabling the `detachedHead` message as well, but _really_ old git versions actually had that message enabled unconditionally, so keeping it enabled in the config is closer to the original (unconfigured) behavior.

## Description of how this change was tested
* Performed linting validation using `pre-commit run --all`
* Verified that the code passes all tests using `pytest -s -v test`
* Also confirmed tests pass on older platforms like Ubuntu Xenial