### PR TITLE
Added Pylint rule to enforce toplevel imports.

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -2,6 +2,7 @@
 select = [
     'F',  # Pyflakes
     'I',  # isort
+    'PLC0415' # Pylint rule to ensure import should be on top of the file
 ]
 
 [format]

--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -2,12 +2,15 @@ import os
 import subprocess
 import sys
 import unittest
+from io import StringIO
 from shutil import which
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import vcs2l.executor as executor
+from vcs2l.clients.git import GitClient
+from vcs2l.commands.pull import main
+from vcs2l.util import rmtree
 
-from vcs2l.clients.git import GitClient  # noqa: E402
-from vcs2l.util import rmtree  # noqa: E402
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 file_uri_scheme = 'file://' if sys.platform != 'win32' else 'file:///'
 
@@ -113,10 +116,6 @@ class TestCommands(unittest.TestCase):
         self.assertEqual(output, expected)
 
     def test_pull_api(self):
-        from io import StringIO
-
-        from vcs2l.commands.pull import main
-
         stdout_stderr = StringIO()
 
         # change and restore cwd
@@ -124,8 +123,6 @@ class TestCommands(unittest.TestCase):
         os.chdir(TEST_WORKSPACE)
         try:
             # change and restore USE_COLOR flag
-            from vcs2l import executor
-
             use_color_bck = executor.USE_COLOR
             executor.USE_COLOR = False
             try:

--- a/vcs2l/commands/help.py
+++ b/vcs2l/commands/help.py
@@ -1,6 +1,7 @@
 import argparse
 import sys
 
+from vcs2l import __version__
 from vcs2l.clients import vcs2l_clients
 from vcs2l.commands import vcs2l_commands
 from vcs2l.errors import UnsupportedPythonVersionError
@@ -92,7 +93,6 @@ def get_parser(add_help=True):
         default=False,
         help='Output the available commands along with their descriptions',
     )
-    from vcs2l import __version__
 
     group.add_argument(
         '--version',

--- a/vcs2l/commands/import_.py
+++ b/vcs2l/commands/import_.py
@@ -8,6 +8,7 @@ import yaml
 
 from vcs2l import __version__ as vcs2l_version
 from vcs2l.clients import vcs2l_clients
+from vcs2l.clients.none import NoneClient
 from vcs2l.clients.vcs_base import run_command
 from vcs2l.commands.command import Command, add_common_arguments
 from vcs2l.executor import ansi, execute_jobs, output_repositories, output_results
@@ -189,8 +190,6 @@ def generate_jobs(repos, args):
         path = os.path.join(args.path, path)
         clients = [c for c in vcs2l_clients if c.type == repo['type']]
         if not clients:
-            from vcs2l.clients.none import NoneClient
-
             job = {
                 'client': NoneClient(path),
                 'command': None,

--- a/vcs2l/commands/validate.py
+++ b/vcs2l/commands/validate.py
@@ -2,6 +2,7 @@ import argparse
 import sys
 
 from vcs2l.clients import vcs2l_clients
+from vcs2l.clients.none import NoneClient
 from vcs2l.commands.command import Command, add_common_arguments
 from vcs2l.commands.import_ import get_repositories
 from vcs2l.executor import ansi, execute_jobs, output_results
@@ -40,8 +41,6 @@ def generate_jobs(repos, args):
     for path, repo in repos.items():
         clients = [c for c in vcs2l_clients if c.type == repo['type']]
         if not clients:
-            from vcs2l.clients.none import NoneClient
-
             job = {
                 'client': NoneClient(path),
                 'command': None,


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A |
| Primary OS tested on | Ubuntu |
| Is this a breaking change? | No |
| Does this PR contain [AI generated](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md) software? | No |

---

## Description of contribution in a few bullet points
* Use a Pylint specific rule - [PLC0415](https://docs.astral.sh/ruff/rules/import-outside-top-level/), to enforce only toplevel imports of libraries across all files.
* The use of `streams.stdout` was done over `stdout` in [executor](https://github.com/ros-infrastructure/vcs2l/compare/leander-dsouza/enforce-toplevel-imports?expand=1#diff-df8c8bf51f6a69dd7068519fc74a7780ff61d9c7163b4bde54e8863809b4b56bR29), as the direct value of `stdout` was needed, instead of the reference.

   This is because the local imports presented a fresh copy of `stdout` for use, and by globally importing `streams.stdout`, we can ensure that we are working with a new instance every time.

## Description of how this change was tested
* Performed linting validation using `pre-commit run --all`
* Verified that the code passes all tests using `pytest -s -v test`

## Future work
* The complete [Pylint rule](https://docs.astral.sh/ruff/rules/#pylint-pl) can be enabled in the near future, once each specific rule is tested in sequence.


