### PR TITLE
Fix python version requirement in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open(
 setup(
     name='vcs2l',
     version=__version__,
-    requires_python='>=3.6',
+    python_requires='>=3.6',
     install_requires=[
         "importlib_metadata; python_version<'3.8' and python_version>='3.7'",
         'PyYAML',


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A |
| Primary OS tested on | Fedora |
| Is this a breaking change? | No |
| Does this PR contain [AI generated](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md) software? | No |

---

## Description of contribution in a few bullet points
The option key is `python_requires`, not `requires_python`.

Docs: https://setuptools.pypa.io/en/latest/userguide/declarative_config.html#options

Resolves:
```
setuptools/_distutils/dist.py:289: UserWarning: Unknown distribution option: 'requires_python'
  warnings.warn(msg)
```

## Description of how this change was tested
* Performed linting validation using `pre-commit run --all`
* Verified that the code passes all tests using `pytest -s -v test`
* No warnings when invoking `python3 -m build`
