### PR TITLE
Fix detection of annotated git tags

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -60,7 +60,7 @@ class StagedReposFile(unittest.TestCase):
             ('branch', '--quiet', '-D', 'license'),
             ('commit', '--quiet', '--allow-empty', '-m', 'update changelog'),
             ('commit', '--quiet', '--allow-empty', '-m', '0.1.27'),
-            ('tag', '0.1.27'),
+            ('tag', '0.1.27', '-m', '0.1.27'),
             ('commit', '--quiet', '--allow-empty', '-m', "codin' codin' codin'"),
         ):
             subprocess.check_call(

--- a/vcs2l/clients/git.py
+++ b/vcs2l/clients/git.py
@@ -188,6 +188,7 @@ class GitClient(VcsClientBase):
                             'ls-remote',
                             remote,
                             'refs/tags/' + tag,
+                            'refs/tags/' + tag + '^{}',
                         ]
                         result_ls_remote = self._run_command(cmd_ls_remote)
                         if result_ls_remote['returncode']:
@@ -197,8 +198,10 @@ class GitClient(VcsClientBase):
                             )
                             return result_ls_remote
                         matches = self._get_hash_ref_tuples(result_ls_remote['output'])
-                        if len(matches) == 1 and matches[0][0] == ref:
-                            ref = tag
+                        for match_hash, _ in matches:
+                            if match_hash == ref:
+                                ref = tag
+                                break
 
                 # determine url of remote
                 result_url = self._get_remote_url(remote)


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A |
| Primary OS tested on | Fedora |
| Is this a breaking change? | No |
| Does this PR contain [AI generated](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md) software? | No |

---

## Description of contribution in a few bullet points
This commit extends vcs2l's tag detection scheme to support annotated tags, building on the existing support for lightweight tags. The new detection logic adds awareness of some git plumbing details regarding how the tag's message is stored in relation to the SHA it references.

I updated the test to use an annotated tag for one of the tags in the list to exercise this feature.

Specifically, this affects the `vcs export` command when `--exact-with-tags` is used.

## Description of how this change was tested
* Performed linting validation using `pre-commit run --all`
* Verified that the code passes all tests using `python3 -m pytest -s -v test`

> [!IMPORTANT]
> This is in "draft" against the `cottsay/offline-tests` branch until that PR is merged. I'll then rebase this against `main` for final review.