### PR TITLE
Clarify Humble support on installation steps

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -20,7 +20,7 @@ Follow the official guide for your selected ROS Distro namely
 `Rolling <https://docs.ros.org/en/rolling/Installation/Ubuntu-Install-Debs.html#enable-required-repositories>`_,
 `Kilted <https://docs.ros.org/en/kilted/Installation/Ubuntu-Install-Debs.html#enable-required-repositories>`_,
 `Jazzy <https://docs.ros.org/en/jazzy/Installation/Ubuntu-Install-Debs.html#enable-required-repositories>`_ or
-`Humble <https://docs.ros.org/en/humble/Installation/Ubuntu-Install-Debs.html#setup-sources>_` for this addition.
+`Humble <https://docs.ros.org/en/humble/Installation/Ubuntu-Install-Debs.html#setup-sources>`_ for this addition.
 This is a **required** step for installing vcs2l on Debian-based systems.
 
 Then, install vcs2l:


### PR DESCRIPTION
---
Add Humble to the installation steps list since it's already support with the Jammy release. 

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | resolves #75  |
| Primary OS tested on | None |
| Is this a breaking change? | No |
| Does this PR contain [AI generated](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md) software? | No |

---

## Description of contribution in a few bullet points
<!--
* Briefly describe the changes you made and why they are necessary.
-->
- Fixes bug in documentation that caused confusion on Humble support.
## Description of how this change was tested
<!--
* Performed linting validation using `pre-commit run --all`
* Verified that the code passes all tests using `python3 -m pytest -s -v test`
-->
