### PR TITLE
Upload release upon tagging with created assets.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,9 @@
 name: Release
 
 on:
-  release:
-    types: [created]
+  push:
+    tags:
+      - '[0-9]+\.[0-9]+\.[0-9]+'
 
 jobs:
 
@@ -43,9 +44,12 @@ jobs:
             rrp \
             bash -c "/ros_release_python/scripts/ros_release_python pip"
 
-      - name: Upload assets to release
+      - name: Create Release with Assets
         run: |
-          gh release upload ${{ github.event.release.tag_name }} dist/*
+          gh release create "${{ github.ref_name }}" \
+            --title "${{ github.ref_name }}" \
+            --generate-notes \
+            dist/*
         env:
           GH_TOKEN: ${{ github.token }}
 

--- a/release_playbook.md
+++ b/release_playbook.md
@@ -28,18 +28,15 @@ This playbook outlines the steps to release a new version of the `vcs2l` project
    git push origin main
    ```
 
-## 2. Tagging the release
-After merging the PR, create a new tag for the release using the following commands:
+## 2. Tagging the release and automated publishing
+* After merging the PR, create a new tag for the repository using the following commands:
 
-```bash
-git checkout main
-git tag x.y.z
-git push origin x.y.z
-```
+   ```bash
+   git checkout main
+   git tag x.y.z
+   git push origin x.y.z
+   ```
+* Pushing the tag will automatically create a GitHub release with assets - `*.whl` and `*.tar.gz`.
+  The release notes will be generated automatically based on the merged PRs since the last release.
 
-## 3. Publishing the release on GitHub
-* Navigate to the [Releases](https://github.com/ros-infrastructure/vcs2l/releases/new) page, and select the tag you just pushed.
-* Fill in the release title as `x.y.z`.
-* Create the release notes by using the `Generate release notes` button.
-* Publish the release by setting it as the latest release.
-* This will automatically trigger the GitHub Actions workflow to publish the package to PyPI.
+* This would also publish the package onto PyPI with the newly created version.


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A |
| Primary OS tested on | N/A |
| Is this a breaking change? | No|
| Does this PR contain [AI generated](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md) software? | No|

---

## Description of contribution in a few bullet points
* The release workflow is now triggered by pushing a tag, for instance - `1.2.3`.
* Since the addition of immutable releases, the `*.whl` and `*.tar.gz` assets cannot be added after creation of the manual release. Hence, these are added upon creation of the release.
* The playbook has been updated to accommodate the new workflow process.

## Description of how this change was tested
* The workflow was tested in a [local fork](https://github.com/leander-dsouza/vcs2l/releases/tag/1.1.7) with release immutability.