### PR TITLE
Fix path-to-URL conversion on Python 3.14+

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -6,16 +6,15 @@ import subprocess
 import tarfile
 import unittest
 import zipfile
+from pathlib import Path
 from shutil import which
 from tempfile import TemporaryDirectory
-from urllib.parse import urljoin
-from urllib.request import pathname2url
 
 import yaml
 
 
 def to_file_url(path):
-    return urljoin('file:', pathname2url(path))
+    return Path(path).as_uri()
 
 
 class StagedReposFile(unittest.TestCase):


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A |
| Primary OS tested on | Fedora |
| Is this a breaking change? | No |
| Does this PR contain [AI generated](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md) software? | No |

---

## Description of contribution in a few bullet points
I don't really understand why this was working correctly before, but changes to `pathname2url` in Python 3.14 are causing the resulting URL to have only a single leading slash, e.x. `file:/foo/bar`.

Found while packaging `vcs2l` for Fedora Rawhide.

## Description of how this change was tested
* Performed linting validation using `pre-commit run --all`
* Verified that the code passes all tests using `python3 -m pytest -s -v test`