### PR TITLE
Enable commit-specific git fetch for compatibility with external forks.

### DIFF
--- a/test/import.txt
+++ b/test/import.txt
@@ -1,6 +1,8 @@
 ......
 === ./immutable/hash (git) ===
 Cloning into '.'...
+From file:///vcstmp/gitrepo
+ * branch            5b3504594f7354121cf024dc734bf79e270cffd3 -> FETCH_HEAD
 Note: switching to '5b3504594f7354121cf024dc734bf79e270cffd3'.
 
 You are in 'detached HEAD' state. You can look around, make experimental

--- a/test/import.txt
+++ b/test/import.txt
@@ -1,8 +1,14 @@
 ......
 === ./immutable/hash (git) ===
-Cloning into '.'...
+Initialized empty Git repository in ./immutable/hash/.git/
+
 From file:///vcstmp/gitrepo
  * branch            5b3504594f7354121cf024dc734bf79e270cffd3 -> FETCH_HEAD
+ * [new tag]         0.1.26     -> 0.1.26
+ * [new tag]         0.1.27     -> 0.1.27
+ * [new tag]         1.1.3      -> 1.1.3
+ * [new tag]         1.1.4      -> 1.1.4
+ * [new tag]         1.1.5      -> 1.1.5
 Note: switching to '5b3504594f7354121cf024dc734bf79e270cffd3'.
 
 You are in 'detached HEAD' state. You can look around, make experimental
@@ -26,7 +32,11 @@ Downloaded tarball from 'file:///vcstmp/archive.tar.gz' and unpacked it
 === ./immutable/hash_zip (zip) ===
 Downloaded zipfile from 'file:///vcstmp/archive.zip' and unpacked it
 === ./immutable/tag (git) ===
-Cloning into '.'...
+Initialized empty Git repository in ./immutable/tag/.git/
+
+From file:///vcstmp/gitrepo
+ * [new tag]         0.1.27     -> 0.1.27
+ * [new tag]         0.1.26     -> 0.1.26
 Note: switching to 'tags/0.1.27'.
 
 You are in 'detached HEAD' state. You can look around, make experimental

--- a/test/import_blobless.txt
+++ b/test/import_blobless.txt
@@ -2,6 +2,8 @@
 === ./immutable/hash (git) ===
 Cloning into '.'...
 warning: filtering not recognized by server, ignoring
+From file:///vcstmp/gitrepo
+ * branch            5b3504594f7354121cf024dc734bf79e270cffd3 -> FETCH_HEAD
 Note: switching to '5b3504594f7354121cf024dc734bf79e270cffd3'.
 
 You are in 'detached HEAD' state. You can look around, make experimental

--- a/test/import_blobless.txt
+++ b/test/import_blobless.txt
@@ -1,9 +1,15 @@
 ......
 === ./immutable/hash (git) ===
-Cloning into '.'...
+Initialized empty Git repository in ./immutable/hash/.git/
+
 warning: filtering not recognized by server, ignoring
 From file:///vcstmp/gitrepo
  * branch            5b3504594f7354121cf024dc734bf79e270cffd3 -> FETCH_HEAD
+ * [new tag]         0.1.26     -> 0.1.26
+ * [new tag]         0.1.27     -> 0.1.27
+ * [new tag]         1.1.3      -> 1.1.3
+ * [new tag]         1.1.4      -> 1.1.4
+ * [new tag]         1.1.5      -> 1.1.5
 Note: switching to '5b3504594f7354121cf024dc734bf79e270cffd3'.
 
 You are in 'detached HEAD' state. You can look around, make experimental
@@ -27,8 +33,12 @@ Downloaded tarball from 'file:///vcstmp/archive.tar.gz' and unpacked it
 === ./immutable/hash_zip (zip) ===
 Downloaded zipfile from 'file:///vcstmp/archive.zip' and unpacked it
 === ./immutable/tag (git) ===
-Cloning into '.'...
+Initialized empty Git repository in ./immutable/tag/.git/
+
 warning: filtering not recognized by server, ignoring
+From file:///vcstmp/gitrepo
+ * [new tag]         0.1.27     -> 0.1.27
+ * [new tag]         0.1.26     -> 0.1.26
 Note: switching to 'tags/0.1.27'.
 
 You are in 'detached HEAD' state. You can look around, make experimental

--- a/test/pull_first.txt
+++ b/test/pull_first.txt
@@ -1,0 +1,24 @@
+....
+=== ./immutable/hash (git) ===
+From file:///vcstmp/gitrepo
+ * [new branch]      main       -> origin/main
+You are not currently on a branch.
+Please specify which branch you want to merge with.
+See git-pull(1) for details.
+
+    git pull <remote> <branch>
+=== ./immutable/tag (git) ===
+From file:///vcstmp/gitrepo
+ * [new branch]      main       -> origin/main
+ * [new tag]         1.1.5      -> 1.1.5
+ * [new tag]         1.1.3      -> 1.1.3
+ * [new tag]         1.1.4      -> 1.1.4
+You are not currently on a branch.
+Please specify which branch you want to merge with.
+See git-pull(1) for details.
+
+    git pull <remote> <branch>
+=== ./vcs2l (git) ===
+Already up to date.
+=== ./without_version (git) ===
+Already up to date.

--- a/test/reimport_force.txt
+++ b/test/reimport_force.txt
@@ -1,6 +1,7 @@
 ......
 === ./immutable/hash (git) ===
-
+From file:///vcstmp/gitrepo
+ * branch            5b3504594f7354121cf024dc734bf79e270cffd3 -> FETCH_HEAD
 HEAD is now at 5b35045... update changelog
 === ./immutable/hash_tar (tar) ===
 Downloaded tarball from 'file:///vcstmp/archive.tar.gz' and unpacked it

--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -102,7 +102,9 @@ class TestCommands(StagedReposFile):
 
     def test_pull(self):
         output = run_command('pull', args=['--workers', '1'])
-        expected = get_expected_output('pull')
+        # the first pull after import also fetches the default branch and reachable tags,
+        # since a bare hash/tag fetch doesn't retrieve any tags on its own
+        expected = get_expected_output('pull_first')
         # replace message from older git versions
         output = output.replace(
             b'anch. Please specify which\nbranch you want to merge with. See',
@@ -530,12 +532,12 @@ def adapt_command_output(output, cwd=None):
     )
     # normalize temporary path locations
     output = re.sub(rb'file://.*\.vcstmp', b'file:///vcstmp', output)
+    if cwd:
+        # `git init` (used for precise hash/tag clones) prints the absolute
+        # path to the repo, hence make it relative
+        cwd_abs = os.path.abspath(cwd).replace('\\', '/')
+        output = output.replace(cwd_abs.encode(), b'.')
     if sys.platform == 'win32':
-        if cwd:
-            # on Windows, git prints full path to repos
-            # in some messages, so make it relative
-            cwd_abs = os.path.abspath(cwd).replace('\\', '/')
-            output = output.replace(cwd_abs.encode(), b'.')
         # replace path separators in specific paths;
         # this is less likely to cause wrong test results
         paths_to_replace = [

--- a/vcs2l/clients/git.py
+++ b/vcs2l/clients/git.py
@@ -331,13 +331,18 @@ class GitClient(VcsClientBase):
             cmd_fetch = [GitClient._executable, 'fetch', remote]
             if command.blobless_clone:
                 cmd_fetch.append('--filter=blob:none')
-            if command.shallow:
+
+            # Determine version type for both shallow and non-shallow modes
+            version_type, version_name = None, None
+            if checkout_version is not None:
                 result_version_type, version_name = self._check_version_type(
                     command.url, checkout_version, command.retry
                 )
                 if result_version_type['returncode']:
                     return result_version_type
                 version_type = result_version_type['version_type']
+
+            if command.shallow:
                 if version_type == 'branch':
                     cmd_fetch.append(
                         'refs/heads/%s:refs/remotes/%s/%s'
@@ -353,7 +358,9 @@ class GitClient(VcsClientBase):
                     assert False
                 cmd_fetch += ['--depth', '1']
             else:
-                version_type = None
+                # For non-shallow mode, only fetch specific commit hashes
+                if version_type == 'hash':
+                    cmd_fetch.append(checkout_version)
             result_fetch = self._run_command(cmd_fetch, retry=command.retry)
             if result_fetch['returncode']:
                 return result_fetch
@@ -440,6 +447,22 @@ class GitClient(VcsClientBase):
                     return result_clone
                 cmd = result_clone['cmd']
                 output = result_clone['output']
+
+                # For non-shallow clones with commit hashes, fetch the specific commit
+                if not command.shallow and version_type == 'hash':
+                    cmd_fetch_hash = [
+                        GitClient._executable,
+                        'fetch',
+                        'origin',
+                        command.version,
+                    ]
+                    result_fetch_hash = self._run_command(
+                        cmd_fetch_hash, retry=command.retry
+                    )
+                    if result_fetch_hash['returncode']:
+                        return result_fetch_hash
+                    cmd += ' && ' + ' '.join(cmd_fetch_hash)
+                    output = '\n'.join([output, result_fetch_hash['output']])
             else:
                 # getting a hash or tag with a depth of 1 can't use 'clone'
                 cmd_init = [GitClient._executable, 'init']

--- a/vcs2l/clients/git.py
+++ b/vcs2l/clients/git.py
@@ -456,6 +456,8 @@ class GitClient(VcsClientBase):
                         'origin',
                         command.version,
                     ]
+                    if command.blobless_clone:
+                        cmd_fetch_hash.append('--filter=blob:none')
                     result_fetch_hash = self._run_command(
                         cmd_fetch_hash, retry=command.retry
                     )

--- a/vcs2l/clients/git.py
+++ b/vcs2l/clients/git.py
@@ -419,23 +419,13 @@ class GitClient(VcsClientBase):
                     return result_version_type
                 version_type = result_version_type['version_type']
 
-            if not command.shallow or version_type in (None, 'branch'):
+            if version_type in (None, 'branch'):
                 cmd_clone = [GitClient._executable, 'clone', command.url, '.']
                 if command.blobless_clone:
                     cmd_clone += ['--filter=blob:none']
-                    if version_type == 'branch':
-                        cmd_clone += ['-b', version_name]
-                        checkout_version = None
-                    elif command.version:
-                        cmd_clone.append('--no-checkout')
-                        checkout_version = command.version
-                    else:
-                        checkout_version = None
-                elif version_type == 'branch':
+                if version_type == 'branch':
                     cmd_clone += ['-b', version_name]
-                    checkout_version = None
-                else:
-                    checkout_version = command.version
+                checkout_version = None
                 if command.shallow:
                     cmd_clone += ['--depth', '1']
                 result_clone = self._run_command(cmd_clone, retry=command.retry)
@@ -447,26 +437,10 @@ class GitClient(VcsClientBase):
                     return result_clone
                 cmd = result_clone['cmd']
                 output = result_clone['output']
-
-                # For non-shallow clones with commit hashes, fetch the specific commit
-                if not command.shallow and version_type == 'hash':
-                    cmd_fetch_hash = [
-                        GitClient._executable,
-                        'fetch',
-                        'origin',
-                        command.version,
-                    ]
-                    if command.blobless_clone:
-                        cmd_fetch_hash.append('--filter=blob:none')
-                    result_fetch_hash = self._run_command(
-                        cmd_fetch_hash, retry=command.retry
-                    )
-                    if result_fetch_hash['returncode']:
-                        return result_fetch_hash
-                    cmd += ' && ' + ' '.join(cmd_fetch_hash)
-                    output = '\n'.join([output, result_fetch_hash['output']])
             else:
-                # getting a hash or tag with a depth of 1 can't use 'clone'
+                # getting a precise hash or tag doesn't require a full clone,
+                # fetching just the ref avoids downloading
+                # the rest of the repository's history
                 cmd_init = [GitClient._executable, 'init']
                 result_init = self._run_command(cmd_init)
                 if result_init['returncode']:
@@ -488,6 +462,8 @@ class GitClient(VcsClientBase):
                 output = '\n'.join([output, result_remote_add['output']])
 
                 cmd_fetch = [GitClient._executable, 'fetch', 'origin']
+                if command.blobless_clone:
+                    cmd_fetch.append('--filter=blob:none')
                 if version_type == 'hash':
                     cmd_fetch.append(command.version)
                 elif version_type == 'tag':
@@ -496,7 +472,11 @@ class GitClient(VcsClientBase):
                     )
                 else:
                     assert False
-                cmd_fetch += ['--depth', '1']
+                if command.shallow:
+                    cmd_fetch += ['--depth', '1']
+                elif version_type == 'hash':
+                    # fetching a bare hash doesn't retrieve any tags on its own.
+                    cmd_fetch.append('--tags')
                 result_fetch = self._run_command(cmd_fetch, retry=command.retry)
                 if result_fetch['returncode']:
                     return result_fetch


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | resolves #8|
| Primary OS tested on | Ubuntu |
| Is this a breaking change? | No |
| Does this PR contain [AI generated](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md) software? | No |

---

## Description of contribution in a few bullet points
* Enabled commit-specific fetching of origin on non-shallow clones containing hashes.
* This allows us to clone PRs from repositories not tied to the source branch for history (external forks).

## Description of how this change was tested

### 1. Testing against vcs2l old pull requests

* First, clone the codebase:

   ```bash
   git clone git@github.com:ros-infrastructure/vcs2l.git vcs2l-ext-fork
   ```

* Next, use the following `repos.yaml` to get the commit hash of the following [external fork](https://github.com/ros-infrastructure/vcs2l/commit/4ad2dd14b0033c275e5faff7935c4a7d7581fee4):

   ```yaml
   ---
   repositories:
     vcs2l-ext-fork:
       type: git
       url: 'https://github.com/ros-infrastructure/vcs2l.git'
       version: '4ad2dd14b0033c275e5faff7935c4a7d7581fee4'
   ```
* Finally, update the existing repository:

   ```bash
   vcs import --input repos.yaml
   ```
   This will successfully checkout the repository to the specific hash.
   This step fails without this contribution with the following error message:
   
   ```bash
   === ./vcs2l-ext-fork (git) ===
   Could not checkout ref '4ad2dd14b0033c275e5faff7935c4a7d7581fee4': fatal: reference is not a tree:    4ad2dd14b0033c275e5faff7935c4a7d7581fee4
   ```
   
### 2. Test against the reproduction step in the parent issue - https://github.com/dirk-thomas/vcstool/issues/258

* Reproduction measures specified by @timor-raiman

   ```bash
   git clone git@github.com:timor-raiman/action-ros-ci.git -b vcs-issue && cd action-ros-ci
   git fetch origin +refs/pull/3/*:refs/remotes/origin/pr/3/*
   export PRMERGE_SHA=`git rev-parse origin/pr/3/merge`
   rm -rf new-path/ && mkdir -p new-path/
   cat test-vcs-issue.repo | envsubst | vcs import --force --recursive new-path/
   ```
   