### PR TITLE
Add python3-vcs2l-vcstool-shim debian package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(
 ) as f:
     long_description = f.read()
 
-setup(
+kwargs = dict(
     name='vcs2l',
     version=__version__,
     python_requires='>=3.6',
@@ -85,3 +85,28 @@ setup(
         ]
     },
 )
+
+
+if os.environ.get('VCS2L_VCSTOOL_SHIM', ''):
+    vcs2l_suffixes = [pkg[5:] for pkg in kwargs['packages'] if pkg.startswith('vcs2l')]
+
+    kwargs.update(
+        dict(
+            name=kwargs['name'] + '_vcstool_shim',
+            install_requires=kwargs['install_requires'] + ['vcs2l==' + __version__],
+            extras_require={},
+            packages=['vcstool' + suffix for suffix in vcs2l_suffixes],
+            package_dir={
+                'vcstool' + suffix: ('vcs2l' + suffix).replace('.', '/')
+                for suffix in vcs2l_suffixes
+            },
+            description='Backwards compatible vcstool shim package',
+            long_description=None,
+            long_description_content_type=None,
+            data_files=[],
+            entry_points={},
+        )
+    )
+
+
+setup(**kwargs)

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,6 +1,14 @@
 [DEFAULT]
 No-Python2:
 Depends3: python3-yaml
-Conflicts3: python-vcstool, python3-vcstool
+Conflicts3: python-vcstool (<< ${binary:Version}), python3-vcstool (<< ${binary:Version}), vcstool (<< ${binary:Version})
 Suite3: jammy noble bookworm trixie
 X-Python3-Version: >= 3.8
+
+[vcs2l]
+
+[vcs2l_vcstool_shim]
+Depends3: python3-vcs2l (= ${binary:Version}), python3-yaml
+Provides3: python3-vcstool (= ${binary:Version}), vcstool (= ${binary:Version})
+Replaces3: python3-vcstool (= ${binary:Version}), vcstool (= ${binary:Version})
+Setup-Env-Vars: VCS2L_VCSTOOL_SHIM=1


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | resolves #88 |
| Primary OS tested on | Ubuntu |
| Is this a breaking change? | No |
| Does this PR contain [AI generated](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md) software? | No |

---

## Description of contribution in a few bullet points
This sub-package presents vcs2l as a wholesale replacement for vcstool and should satisfy any existing dependencies on vcstool without requiring changes to vcs2l itself. It operates under the fact that the existing vcs2l API is similar enough to vcstool that it can simply be installed and used under that name.

When the vcs2l API deviates from vcstool enough, this commit may be reverted and the shim package dropped.

## Description of how this change was tested
* Performed linting validation using `pre-commit run --all`
* Verified that the code passes all tests using `python3 -m pytest -s -v test`
* Verified that debs satisfy dependency on `python3-vcstool`

