### PR TITLE
feat: blobless clone

### DIFF
--- a/test/import_blobless.txt
+++ b/test/import_blobless.txt
@@ -1,0 +1,53 @@
+......
+=== ./immutable/hash (git) ===
+Cloning into '.'...
+warning: filtering not recognized by server, ignoring
+Note: switching to '5b3504594f7354121cf024dc734bf79e270cffd3'.
+
+You are in 'detached HEAD' state. You can look around, make experimental
+changes and commit them, and you can discard any commits you make in this
+state without impacting any branches by switching back to a branch.
+
+If you want to create a new branch to retain commits you create, you may
+do so (now or later) by using -c with the switch command. Example:
+
+  git switch -c <new-branch-name>
+
+Or undo this operation with:
+
+  git switch -
+
+Turn off this advice by setting config variable advice.detachedHead to false
+
+HEAD is now at 5b35045... update changelog
+=== ./immutable/hash_tar (tar) ===
+Downloaded tarball from 'file:///vcstmp/archive.tar.gz' and unpacked it
+=== ./immutable/hash_zip (zip) ===
+Downloaded zipfile from 'file:///vcstmp/archive.zip' and unpacked it
+=== ./immutable/tag (git) ===
+Cloning into '.'...
+warning: filtering not recognized by server, ignoring
+Note: switching to 'tags/0.1.27'.
+
+You are in 'detached HEAD' state. You can look around, make experimental
+changes and commit them, and you can discard any commits you make in this
+state without impacting any branches by switching back to a branch.
+
+If you want to create a new branch to retain commits you create, you may
+do so (now or later) by using -c with the switch command. Example:
+
+  git switch -c <new-branch-name>
+
+Or undo this operation with:
+
+  git switch -
+
+Turn off this advice by setting config variable advice.detachedHead to false
+
+HEAD is now at 8087b72... 0.1.27
+=== ./vcs2l (git) ===
+Cloning into '.'...
+warning: filtering not recognized by server, ignoring
+=== ./without_version (git) ===
+Cloning into '.'...
+warning: filtering not recognized by server, ignoring

--- a/test/import_blobless_shallow_mutually_exclusive.txt
+++ b/test/import_blobless_shallow_mutually_exclusive.txt
@@ -1,1 +1,0 @@
-'--shallow' and '--blobless-clone' are mutually exclusive options

--- a/test/import_blobless_shallow_mutually_exclusive.txt
+++ b/test/import_blobless_shallow_mutually_exclusive.txt
@@ -1,0 +1,1 @@
+'--shallow' and '--blobless-clone' are mutually exclusive options

--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -309,31 +309,6 @@ class TestCommands(StagedReposFile):
         finally:
             rmtree(workdir)
 
-    def test_import_blobless_shallow_mutually_exclusive(self):
-        repo_root = os.path.dirname(os.path.dirname(__file__))
-        script = os.path.join(repo_root, 'scripts', 'vcs-import')
-        try:
-            subprocess.check_output(
-                [
-                    sys.executable,
-                    script,
-                    '--shallow',
-                    '--blobless-clone',
-                    '--input',
-                    self.repos_file_path,
-                    '.',
-                ],
-                stderr=subprocess.STDOUT,
-                cwd=TEST_WORKSPACE,
-            )
-        except subprocess.CalledProcessError as e:
-            output = adapt_command_output(e.output, TEST_WORKSPACE)
-        else:
-            self.fail("Expected '--shallow' and '--blobless-clone' to be rejected")
-
-        expected = get_expected_output('import_blobless_shallow_mutually_exclusive')
-        self.assertEqual(output, expected)
-
     def test_import_url(self):
         workdir = os.path.join(TEST_WORKSPACE, 'import-url')
         os.makedirs(workdir)

--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -270,6 +270,78 @@ class TestCommands(StagedReposFile):
         finally:
             rmtree(workdir)
 
+    def test_import_blobless(self):
+        workdir = os.path.join(TEST_WORKSPACE, 'import-blobless')
+        os.makedirs(workdir)
+        try:
+            output = run_command(
+                'import',
+                ['--blobless-clone', '--input', self.repos_file_path, '.'],
+                subfolder='import-blobless',
+            )
+            # the actual output contains absolute paths
+            output = output.replace(
+                b'repository in ' + workdir.encode() + b'/', b'repository in ./'
+            )
+            expected = get_expected_output('import_blobless')
+            # newer git versions don't append ... after the commit hash
+            assert output == expected or output == expected.replace(b'... ', b' ')
+
+            git_repos = [
+                os.path.join(workdir, 'immutable', 'hash'),
+                os.path.join(workdir, 'immutable', 'tag'),
+                os.path.join(workdir, 'vcs2l'),
+                os.path.join(workdir, 'without_version'),
+            ]
+            for repo_path in git_repos:
+                partial_filter = subprocess.check_output(
+                    ['git', 'config', '--get', 'remote.origin.partialclonefilter'],
+                    stderr=subprocess.STDOUT,
+                    cwd=repo_path,
+                ).strip()
+                self.assertEqual(partial_filter, b'blob:none')
+                promisor = subprocess.check_output(
+                    ['git', 'config', '--get', 'remote.origin.promisor'],
+                    stderr=subprocess.STDOUT,
+                    cwd=repo_path,
+                ).strip()
+                self.assertEqual(promisor, b'true')
+        finally:
+            rmtree(workdir)
+
+    def test_import_blobless_shallow_mutually_exclusive(self):
+        repo_root = os.path.dirname(os.path.dirname(__file__))
+        script = os.path.join(repo_root, 'scripts', 'vcs-import')
+        env = dict(os.environ)
+        env.update(
+            GIT_CONFIG_GLOBAL=os.path.join(repo_root, 'test', '.gitconfig'),
+            LANG='en_US.UTF-8',
+            PYTHONPATH=repo_root + os.pathsep + env.get('PYTHONPATH', ''),
+            PYTHONWARNINGS='ignore',
+        )
+        try:
+            subprocess.check_output(
+                [
+                    sys.executable,
+                    script,
+                    '--shallow',
+                    '--blobless-clone',
+                    '--input',
+                    self.repos_file_path,
+                    '.',
+                ],
+                stderr=subprocess.STDOUT,
+                cwd=TEST_WORKSPACE,
+                env=env,
+            )
+        except subprocess.CalledProcessError as e:
+            output = adapt_command_output(e.output, TEST_WORKSPACE)
+        else:
+            self.fail("Expected '--shallow' and '--blobless-clone' to be rejected")
+
+        expected = get_expected_output('import_blobless_shallow_mutually_exclusive')
+        self.assertEqual(output, expected)
+
     def test_import_url(self):
         workdir = os.path.join(TEST_WORKSPACE, 'import-url')
         os.makedirs(workdir)

--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -312,13 +312,6 @@ class TestCommands(StagedReposFile):
     def test_import_blobless_shallow_mutually_exclusive(self):
         repo_root = os.path.dirname(os.path.dirname(__file__))
         script = os.path.join(repo_root, 'scripts', 'vcs-import')
-        env = dict(os.environ)
-        env.update(
-            GIT_CONFIG_GLOBAL=os.path.join(repo_root, 'test', '.gitconfig'),
-            LANG='en_US.UTF-8',
-            PYTHONPATH=repo_root + os.pathsep + env.get('PYTHONPATH', ''),
-            PYTHONWARNINGS='ignore',
-        )
         try:
             subprocess.check_output(
                 [
@@ -332,7 +325,6 @@ class TestCommands(StagedReposFile):
                 ],
                 stderr=subprocess.STDOUT,
                 cwd=TEST_WORKSPACE,
-                env=env,
             )
         except subprocess.CalledProcessError as e:
             output = adapt_command_output(e.output, TEST_WORKSPACE)

--- a/vcs2l/clients/git.py
+++ b/vcs2l/clients/git.py
@@ -326,6 +326,8 @@ class GitClient(VcsClientBase):
 
             # fetch updates for existing repo
             cmd_fetch = [GitClient._executable, 'fetch', remote]
+            if command.blobless_clone:
+                cmd_fetch.append('--filter=blob:none')
             if command.shallow:
                 result_version_type, version_name = self._check_version_type(
                     command.url, checkout_version, command.retry
@@ -409,7 +411,10 @@ class GitClient(VcsClientBase):
 
             if not command.shallow or version_type in (None, 'branch'):
                 cmd_clone = [GitClient._executable, 'clone', command.url, '.']
-                if version_type == 'branch':
+                if command.blobless_clone:
+                    cmd_clone += ['--filter=blob:none', '--no-checkout']
+                    checkout_version = command.version
+                elif version_type == 'branch':
                     cmd_clone += ['-b', version_name]
                     checkout_version = None
                 else:

--- a/vcs2l/clients/git.py
+++ b/vcs2l/clients/git.py
@@ -415,6 +415,7 @@ class GitClient(VcsClientBase):
                     cmd_clone += ['--filter=blob:none']
                     if version_type == 'branch':
                         cmd_clone += ['-b', version_name]
+                        checkout_version = None
                     elif command.version:
                         cmd_clone.append('--no-checkout')
                         checkout_version = command.version

--- a/vcs2l/clients/git.py
+++ b/vcs2l/clients/git.py
@@ -412,8 +412,14 @@ class GitClient(VcsClientBase):
             if not command.shallow or version_type in (None, 'branch'):
                 cmd_clone = [GitClient._executable, 'clone', command.url, '.']
                 if command.blobless_clone:
-                    cmd_clone += ['--filter=blob:none', '--no-checkout']
-                    checkout_version = command.version
+                    cmd_clone += ['--filter=blob:none']
+                    if version_type == 'branch':
+                        cmd_clone += ['-b', version_name]
+                    elif command.version:
+                        cmd_clone.append('--no-checkout')
+                        checkout_version = command.version
+                    else:
+                        checkout_version = None
                 elif version_type == 'branch':
                     cmd_clone += ['-b', version_name]
                     checkout_version = None

--- a/vcs2l/commands/import_.py
+++ b/vcs2l/commands/import_.py
@@ -28,6 +28,7 @@ class ImportCommand(Command):
         self.skip_existing = args.skip_existing
         self.recursive = recursive
         self.shallow = shallow
+        self.blobless_clone = args.blobless_clone
 
 
 def get_parser():
@@ -74,6 +75,12 @@ def get_parser():
         default=False,
         help="Don't overwrite existing directories or change custom checkouts "
         'in repos using the same URL (but fetch repos with same URL)',
+    )
+    group.add_argument(
+        '--blobless-clone',
+        action='store_true',
+        default=False,
+        help='Only clone the commit history first, then checkout to the target version to obtain files',
     )
 
     return parser

--- a/vcs2l/commands/import_.py
+++ b/vcs2l/commands/import_.py
@@ -58,11 +58,18 @@ def get_parser():
         help="Delete existing directories if they don't contain the "
         'repository being imported',
     )
-    group.add_argument(
+    clone_type_group = group.add_mutually_exclusive_group()
+    clone_type_group.add_argument(
         '--shallow',
         action='store_true',
         default=False,
         help='Create a shallow clone without a history',
+    )
+    clone_type_group.add_argument(
+        '--blobless-clone',
+        action='store_true',
+        default=False,
+        help='Only clone the commit history first, then checkout to the target version to obtain files',
     )
     group.add_argument(
         '--recursive',
@@ -83,12 +90,6 @@ def get_parser():
         default=False,
         help="Don't overwrite existing directories or change custom checkouts "
         'in repos using the same URL (but fetch repos with same URL)',
-    )
-    group.add_argument(
-        '--blobless-clone',
-        action='store_true',
-        default=False,
-        help='Only clone the commit history first, then checkout to the target version to obtain files',
     )
 
     return parser
@@ -264,15 +265,6 @@ def main(args=None, stdout=None, stderr=None):
         print(ansi('redf') + str(e) + ansi('reset'), file=sys.stderr)
         return 1
 
-    # check if both '--shallow' and '--blobless-clone' options are used, since they are mutually exclusive
-    if args.shallow and args.blobless_clone:
-        print(
-            ansi('redf')
-            + "'--shallow' and '--blobless-clone' are mutually exclusive options"
-            + ansi('reset'),
-            file=sys.stderr,
-        )
-        return 1
     jobs = generate_jobs(repos, args)
     add_dependencies(jobs)
 

--- a/vcs2l/commands/import_.py
+++ b/vcs2l/commands/import_.py
@@ -19,7 +19,15 @@ class ImportCommand(Command):
     command = 'import'
     help = 'Import the list of repositories'
 
-    def __init__(self, args, url, version=None, recursive=False, shallow=False):
+    def __init__(
+        self,
+        args,
+        url,
+        version=None,
+        recursive=False,
+        shallow=False,
+        blobless_clone=False,
+    ):
         super(ImportCommand, self).__init__(args)
         self.url = url
         self.version = version
@@ -28,7 +36,7 @@ class ImportCommand(Command):
         self.skip_existing = args.skip_existing
         self.recursive = recursive
         self.shallow = shallow
-        self.blobless_clone = args.blobless_clone
+        self.blobless_clone = blobless_clone
 
 
 def get_parser():
@@ -214,6 +222,7 @@ def generate_jobs(repos, args):
             str(repo['version']) if 'version' in repo else None,
             recursive=args.recursive,
             shallow=args.shallow,
+            blobless_clone=args.blobless_clone,
         )
         job = {'client': client, 'command': command}
         jobs.append(job)

--- a/vcs2l/commands/import_.py
+++ b/vcs2l/commands/import_.py
@@ -263,6 +263,16 @@ def main(args=None, stdout=None, stderr=None):
     except (RuntimeError, request.URLError) as e:
         print(ansi('redf') + str(e) + ansi('reset'), file=sys.stderr)
         return 1
+
+    # check if both '--shallow' and '--blobless-clone' options are used, since they are mutually exclusive
+    if args.shallow and args.blobless_clone:
+        print(
+            ansi('redf')
+            + "'--shallow' and '--blobless-clone' are mutually exclusive options"
+            + ansi('reset'),
+            file=sys.stderr,
+        )
+        return 1
     jobs = generate_jobs(repos, args)
     add_dependencies(jobs)
 


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | resolves #91; |
| Primary OS tested on | Ubuntu |
| Is this a breaking change? | No|
| Does this PR contain [AI generated](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md) software? | No; |

---

## Description of contribution in a few bullet points
<!--
* Briefly describe the changes you made and why they are necessary.
-->

- For vcs import, add an optional argument `blobless-clone`
- In git import: 
   - If there is no existing repository, it will perform a blobless clone, then require a follow-up checkout.
   - If there is an existing repository, it will perform fetch with the blobless option.

Related Links:

https://github.com/dirk-thomas/vcstool/pull/283

## Description of how this change was tested
<!--
* Performed linting validation using `pre-commit run --all`
* Verified that the code passes all tests using `python3 -m pytest -s -v test`
-->
- run precommit before committing.
- existing test passed.

Based on the current autoware repos, I run the following commands:
<img width="662" height="245" alt="image" src="https://github.com/user-attachments/assets/a847d28e-bbbe-4b80-8f3a-4afb75255fd9" />

The resulting directory will have a size difference like this, but all required contents exist:
<img width="679" height="310" alt="image" src="https://github.com/user-attachments/assets/ce83ce4e-b6fa-457d-93c0-33140264aa38" />

