### PR TITLE
Update installation instructions using ROS 2 keyring and repository (fixes #112)

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ If the command should work on multiple repositories make sure to pass only gener
 
 # How to install vcs2l?
 
-On Debian-based platforms the recommended method is to configure the repository and install the package *python3-vcs2l* by running:
+On Debian-based platforms the recommended method is to configure the ROS repository and install the package *python3-vcs2l* by running:
 
 ```bash
 sudo apt update && sudo apt install curl -y

--- a/README.md
+++ b/README.md
@@ -323,11 +323,13 @@ On Debian-based platforms the recommended method is to install the package *pyth
 If you are using [ROS](https://www.ros.org/) you can get the package directly from the ROS repository:
 
 ```bash
-sudo apt-get update && sudo apt-get install curl -y
-curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
-echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
-sudo apt-get update
-sudo apt-get install python3-vcs2l
+  sudo apt update && sudo apt install curl -y
+  export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F'"' '{print $4}')
+  curl -L -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo ${UBUNTU_CODENAME:-${VERSION_CODENAME}})_all.deb"
+  sudo dpkg -i /tmp/ros2-apt-source.deb
+  sudo apt update
+  sudo apt install python3-vcs2l
+
 ```
 
 On other systems, use the [PyPI](https://pypi.org/project/vcs2l/) package:

--- a/README.md
+++ b/README.md
@@ -323,9 +323,9 @@ On Debian-based platforms the recommended method is to install the package *pyth
 If you are using [ROS](https://www.ros.org/) you can get the package directly from the ROS repository:
 
 ```bash
-sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
-sudo apt install curl # if you haven't already installed curl
-curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add -
+sudo apt-get update && sudo apt-get install curl -y
+curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
 sudo apt-get update
 sudo apt-get install python3-vcs2l
 ```

--- a/README.md
+++ b/README.md
@@ -321,12 +321,12 @@ If the command should work on multiple repositories make sure to pass only gener
 On Debian-based platforms the recommended method is to configure the repository and install the package *python3-vcs2l* by running:
 
 ```bash
-  sudo apt update && sudo apt install curl -y
-  export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F'"' '{print $4}')
-  curl -L -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo ${UBUNTU_CODENAME:-${VERSION_CODENAME}})_all.deb"
-  sudo dpkg -i /tmp/ros2-apt-source.deb
-  sudo apt update
-  sudo apt install python3-vcs2l
+sudo apt update && sudo apt install curl -y
+export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F'"' '{print $4}')
+curl -L -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo ${UBUNTU_CODENAME:-${VERSION_CODENAME}})_all.deb"
+sudo dpkg -i /tmp/ros2-apt-source.deb
+sudo apt update
+sudo apt install python3-vcs2l
 ```
 
 On other systems, use the [PyPI](https://pypi.org/project/vcs2l/) package:

--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ If the command should work on multiple repositories make sure to pass only gener
 
 On Debian-based platforms the recommended method is to install the package *python3-vcs2l*. On Ubuntu this is done using *apt-get*:
 
-If you are using [ROS](https://www.ros.org/) you can get the package directly from the ROS repository:
+If you are using [ROS](https://www.ros.org/) you can get the package running:
 
 ```bash
   sudo apt update && sudo apt install curl -y

--- a/README.md
+++ b/README.md
@@ -318,9 +318,7 @@ If the command should work on multiple repositories make sure to pass only gener
 
 # How to install vcs2l?
 
-On Debian-based platforms the recommended method is to install the package *python3-vcs2l*. On Ubuntu this is done using *apt-get*:
-
-If you are using [ROS](https://www.ros.org/) you can get the package running:
+On Debian-based platforms the recommended method is to configure the repository and install the package *python3-vcs2l* by running:
 
 ```bash
   sudo apt update && sudo apt install curl -y
@@ -329,7 +327,6 @@ If you are using [ROS](https://www.ros.org/) you can get the package running:
   sudo dpkg -i /tmp/ros2-apt-source.deb
   sudo apt update
   sudo apt install python3-vcs2l
-
 ```
 
 On other systems, use the [PyPI](https://pypi.org/project/vcs2l/) package:


### PR DESCRIPTION
This PR resolves #112 by updating the Debian/Ubuntu installation instructions in the `README.md`. It eliminates the deprecated `apt-key` utility. Instead of manually handling keyring files and source list syntax, it  leverage the official `ros2-apt-source` bootstrap package.

### Verification & Validation
The installation instructions were successfully validated folllowing the updated instructions on a clean `ubuntu:noble` (Ubuntu 24.04) Docker container:

```bash
$ dpkg -S /usr/bin/vcs
python3-vcs2l: /usr/bin/vcs

$ apt show python3-vcs2l
Package: python3-vcs2l
Version: 1.1.7-1
Priority: optional
Section: python
Maintainer: Dirk Thomas <web@dirk-thomas.net>
Installed-Size: 202 kB
Provides: python3-vcstool (= 1.1.7-1), vcstool (= 1.1.7-1)
Depends: python3:any (>= 3.8~), python3-yaml
Conflicts: python-vcstool (<< 1.1.7-1), python3-vcstool (<< 1.1.7-1), vcstool (<< 1.1.7-1)
Replaces: python3-vcstool (= 1.1.7-1), vcstool (= 1.1.7-1)
Homepage: https://github.com/ros-infrastructure/vcs2l
Download-Size: 29.3 kB
APT-Manual-Installed: yes
APT-Sources: http://packages.ros.org/ros2/ubuntu noble/main amd64 Packages
Description: vcs2l provides a command line tool to invoke vcs commands on
 # What is vcs2l?
 .
 Vcs2l is a fork of Dirk Thomas's [`vcstool`](https://github.com/dirk-thomas/vcstool/) which is a version control system (VCS) tool, designed to make working with multiple repositories easier.
 .
 This fork is created to continue the development of `vcstool`, as it is no longer actively maintained.
 .
 The commands provided by vcs2l have the same naming structure as the original fork, so it can be used as a drop-in replacement. Therefore, the repository is renamed to `vcs2l` while maintaining the command names to `vcstool` to ensure compatibility with existing scripts and workflows.
 .
 For more information on how to use vcs2l, please refer to the [**documentation**](https://ros-infrastructure.github.io/vcs2l/index.html).
 .
 ### Note:
 This tool should not be confused with [vcstools](https://github.com/vcstools/vcstools/) (with a trailing `s`) which provides a Python API for interacting with different version control systems.
 .
 The biggest differences between the two are:
 - `vcstool` doesn't use any state beside the repository working copies available in the filesystem.
 - The file format of `vcstool export` uses the relative paths of the repositories as keys in YAML which avoids collisions by design.
 - `vcstool` has significantly fewer lines of code than `vcstools` including the command line tools built on top.
 .
 ## Python 3.6+ support
```