### PR TITLE
fix: resolve ResourceWarning from unclosed file handles in validate and import (fixes #116)

### DIFF
--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -7,7 +7,9 @@ from io import StringIO
 
 import vcs2l.executor as executor
 from vcs2l.clients.git import GitClient
+from vcs2l.commands.import_ import main as import_main
 from vcs2l.commands.pull import main
+from vcs2l.commands.validate import main as validate_main
 from vcs2l.util import rmtree
 
 from . import StagedReposFile, StagedReposFile2, to_file_url
@@ -564,3 +566,35 @@ def get_expected_output(name):
 
 if __name__ == '__main__':
     unittest.main()
+
+
+class TestDirectMainCall(StagedReposFile):
+    def setUp(self):
+        super().setUp()
+        self.stdout = StringIO()
+        self.stderr = StringIO()
+
+    def test_validate_main_with_file(self):
+        rc = validate_main(
+            args=['--input', self.repos_file_path],
+            stdout=self.stdout,
+            stderr=self.stderr,
+        )
+        self.assertEqual(rc, 0)
+
+    def test_import_main_with_file(self):
+        workdir = os.path.join(TEST_WORKSPACE, 'import-direct-file')
+        os.makedirs(workdir, exist_ok=True)
+
+        cwd_bck = os.getcwd()
+        os.chdir(workdir)
+        try:
+            rc = import_main(
+                args=['--input', self.repos_file_path, '.'],
+                stdout=self.stdout,
+                stderr=self.stderr,
+            )
+            self.assertEqual(rc, 0)
+        finally:
+            os.chdir(cwd_bck)
+            rmtree(workdir)

--- a/vcs2l/commands/import_.py
+++ b/vcs2l/commands/import_.py
@@ -98,7 +98,7 @@ def get_parser():
 
 def file_or_url_type(value):
     if os.path.exists(value) or '://' not in value:
-        return argparse.FileType('r')(value)
+        return value
     # use another user agent to avoid getting a 403 (forbidden) error,
     # since some websites blacklist or block unrecognized user agents
     return request.Request(value, headers={'User-Agent': 'vcs2l/' + vcs2l_version})
@@ -331,9 +331,15 @@ def main(args=None, stdout=None, stderr=None):
     try:
         input_ = args.input
         if isinstance(input_, request.Request):
-            input_ = request.urlopen(input_)
-        repos = get_repositories(input_)
-    except (RuntimeError, request.URLError) as e:
+            with request.urlopen(input_) as f:
+                f.name = f.geturl()
+                repos = get_repositories(f)
+        elif input_ == '-':
+            repos = get_repositories(sys.stdin)
+        else:
+            with open(input_, 'r', encoding='utf-8') as f:
+                repos = get_repositories(f)
+    except (RuntimeError, request.URLError, FileNotFoundError) as e:
         print(ansi('redf') + str(e) + ansi('reset'), file=sys.stderr)
         return 1
 

--- a/vcs2l/commands/validate.py
+++ b/vcs2l/commands/validate.py
@@ -25,7 +25,7 @@ def get_parser():
         description='Validate a repositories file', prog='vcs validate'
     )
     group = parser.add_argument_group('"validate" command parameters')
-    group.add_argument('--input', type=argparse.FileType('r'), default='-')
+    group.add_argument('--input', type=str, default='-')
     group.add_argument(
         '--retry',
         type=int,
@@ -68,8 +68,12 @@ def main(args=None, stdout=None, stderr=None):
     add_common_arguments(parser, skip_nested=True, path_nargs=False)
     args = parser.parse_args(args)
     try:
-        repos = get_repositories(args.input)
-    except RuntimeError as e:
+        if args.input == '-':
+            repos = get_repositories(sys.stdin)
+        else:
+            with open(args.input, 'r', encoding='utf-8') as f:
+                repos = get_repositories(f)
+    except (RuntimeError, FileNotFoundError) as e:
         print(ansi('redf') + str(e) + ansi('reset'), file=sys.stderr)
         return 1
 


### PR DESCRIPTION
## Basic Info

The commands vcs validate and vcs import used `argparse.FileType('r')` which opens files at parse-time but doesn't provide a way to close them, resulting in unclosed file handle warnings.

This PR replaces `argparse.FileType` with string path arguments and explicitly manages the file descriptors using context managers for files, standard input, and URL streams.

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | resolves #116 |
| Primary OS tested on | Ubuntu |
| Is this a breaking change? | No |
| Does this PR contain [AI generated](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md) software? | Yes |

---

## Description of contribution in a few bullet points
* **Replaced `argparse.FileType` with string arguments:** Avoids opening files at argument parse time, preventing automatic file handle leaks.
* **Implemented Context Managers:** Ensures that local input files and remote URL streams are closed deterministically immediately after they are read.
* **Maintained Backwards Compatibility:** Added explicit handling for stdin (`-`) to preserve standard pipe-input workflows without closing the system's stdin stream.

## Description of how this change was tested
1.  **Clone repository and create a Test File:**
    -   Create a file named `example.repos` with the following content:
        ```yaml
        repositories:
          foo:
            type: git
            url: https://example.com/foo.git
            version: main
        ```

2.  **Reproduce the Warning (on `main` branch):**
    -   Run the `validate` command with warnings enabled:
        ```sh
        PYTHONWARNINGS=default vcs validate --input example.repos --retry 0
        ```
    -   You should see a `ResourceWarning: unclosed file` in the output.

4.  **Verify the Fix (on `fix/resource-warning-FileType` branch):**
    -   Run the same command again:
        ```sh
        PYTHONWARNINGS=default vcs validate --input example.repos --retry 0
        ```
    -   **Expected:** The command runs without any `ResourceWarning`.
    -   Verify with the `import` command and with stdin as well:
        ```sh
        PYTHONWARNINGS=default vcs import --input example.repos --retry 0
        cat example.repos | PYTHONWARNINGS=default vcs validate --input - --retry 0
        cat example.repos | PYTHONWARNINGS=default vcs import --input - --retry 0
        ```
    -   **Expected:** No warnings are shown for any of the commands.
